### PR TITLE
Add namespace for Katana Elements propertie structs

### DIFF
--- a/Demo/UI/CounterScreen.swift
+++ b/Demo/UI/CounterScreen.swift
@@ -41,13 +41,13 @@ struct CounterScreen: ConnectedNodeDescription, PlasticNodeDescription, PlasticR
                                           dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
     
     return [
-      Label(props: LabelProps.build({
+      Label(props: Label.Props.build({
         $0.setKey(Keys.label)
         $0.textAlignment = .center
         $0.backgroundColor = .mediumAquamarine
         $0.text = NSAttributedString(string: "Count: \(props.count)")
       })),
-      Button(props: ButtonProps.build({
+      Button(props: Button.Props.build({
         $0.setKey(Keys.decrementButton)
         $0.titles[.normal] = "Decrement"
         $0.backgroundColor = .dogwoodRose
@@ -59,7 +59,7 @@ struct CounterScreen: ConnectedNodeDescription, PlasticNodeDescription, PlasticR
           }
         ]
       })),
-      Button(props: ButtonProps.build({
+      Button(props: Button.Props.build({
         $0.setKey(Keys.incrementButton)
         $0.titles[.normal] = "Increment"
         $0.backgroundColor = .japaneseIndigo
@@ -90,8 +90,6 @@ struct CounterScreen: ConnectedNodeDescription, PlasticNodeDescription, PlasticR
     incrementButton.bottom = decrementButton.bottom
     [decrementButton, incrementButton].fill(left: rootView.left, right: rootView.right)
   }
-
-  
 }
 
 

--- a/Examples/CodingLove/CodingLove/UI/CodingLove.swift
+++ b/Examples/CodingLove/CodingLove/UI/CodingLove.swift
@@ -90,14 +90,14 @@ struct CodingLove: ConnectedNodeDescription, PlasticNodeDescription, PlasticRefe
                                      update: @escaping (StateType)->(),
                                      dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
         return [
-            Label(props: LabelProps.build({
+            Label(props: Label.Props.build({
                 $0.setKey(Keys.titleLabel)
                 $0.text = NSAttributedString(string: "The Coding Love", attributes: [
                     NSFontAttributeName: UIFont.systemFont(ofSize: 25)
                 ])
                 $0.textAlignment = NSTextAlignment.center
             })),
-            Table(props: TableProps.build({
+            Table(props: Table.Props.build({
                 $0.setKey(Keys.tableView)
                 $0.delegate = TableViewDelegate(posts: props.posts)
             }))

--- a/Examples/CodingLove/CodingLove/UI/FetchMoreCell.swift
+++ b/Examples/CodingLove/CodingLove/UI/FetchMoreCell.swift
@@ -51,7 +51,7 @@ struct FetchMoreCell: PlasticNodeDescription, PlasticReferenceSizeable, TableCel
         }
         
         return [
-            Label(props: LabelProps.build({
+            Label(props: Label.Props.build({
                 $0.key = Keys.label.rawValue
                 $0.text = NSAttributedString(string: labelText, attributes: [
                     NSFontAttributeName: UIFont.systemFont(ofSize: 16)

--- a/Examples/CodingLove/CodingLove/UI/PostCell.swift
+++ b/Examples/CodingLove/CodingLove/UI/PostCell.swift
@@ -39,7 +39,7 @@ struct PostCell: PlasticNodeDescription, PlasticReferenceSizeable, TableCell, Co
                                      update: @escaping (StateType)->(),
                                      dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
         return [
-            Label(props: LabelProps.build({
+            Label(props: Label.Props.build({
                 $0.setKey(Keys.titleLabel)
                 $0.text = NSAttributedString(string: (props.post?.title)!, attributes: [
                     NSFontAttributeName: UIFont.systemFont(ofSize: 18)
@@ -47,7 +47,7 @@ struct PostCell: PlasticNodeDescription, PlasticReferenceSizeable, TableCell, Co
                 $0.textAlignment = NSTextAlignment.center
                 $0.numberOfLines = 0
             })),
-            Image(props: ImageProps.build({
+            Image(props: Image.Props.build({
                 $0.setKey(Keys.gifImage)
                 $0.image = UIImage.gif(data: (props.post?.imageData)!)
                 $0.backgroundColor = UIColor.lightGray

--- a/Examples/PokeAnimations/PokeAnimations/UI/Intro/Intro.swift
+++ b/Examples/PokeAnimations/PokeAnimations/UI/Intro/Intro.swift
@@ -33,7 +33,7 @@ struct Intro: PlasticNodeDescription, PlasticReferenceSizeable {
       
       View.pokemonBackground(for: state.step),
       
-      Button(props: ButtonProps.build {
+      Button(props: Button.Props.build {
         $0.setKey(ChildrenKeys.button)
         $0.backgroundColor = UIColor(white: 1, alpha: 0.4)
         $0.cornerRadius = .scalable(20)

--- a/Examples/PokeAnimations/PokeAnimations/UI/Intro/KatanaElements+Intro.swift
+++ b/Examples/PokeAnimations/PokeAnimations/UI/Intro/KatanaElements+Intro.swift
@@ -26,7 +26,7 @@ extension View {
       }
     }()
     
-    return View(props: ViewProps.build {
+    return View(props: View.Props.build {
       $0.backgroundColor = color
       $0.setKey(Intro.ChildrenKeys.background)
     })
@@ -62,7 +62,7 @@ extension Image {
       }
     }()
     
-    return Image(props: ImageProps.build {
+    return Image(props: Image.Props.build {
       $0.image = image
       $0.backgroundColor = .clear
       $0.setKey(key)
@@ -99,7 +99,7 @@ extension Label {
       }
     }()
     
-    return Label(props: LabelProps.build {
+    return Label(props: Label.Props.build {
       $0.text = .paragraphString(content)
       $0.textAlignment = .center
       $0.numberOfLines = 0

--- a/KatanaElements/Button.swift
+++ b/KatanaElements/Button.swift
@@ -9,46 +9,47 @@
 import UIKit
 import Katana
 
-public struct ButtonProps: NodeDescriptionProps, Buildable {
-  public var frame = CGRect.zero
-  public var key: String?
-  public var alpha: CGFloat = 1.0
-  
-  public var backgroundColor = UIColor.white
-  public var cornerRadius: Value = .zero
-  public var borderWidth: Value = .zero
-  public var borderColor = UIColor.clear
-  public var clipsToBounds = true
-  public var isEnabled = true
-  public var contentEdgeInsets: EdgeInsets = .zero
-  public var titleEdgeInsets: EdgeInsets = .zero
-  public var imageEdgeInsets: EdgeInsets = .zero
-  public var adjustsImageWhenHighlighted = true
-  public var adjustsImageWhenDisabled = true
-  public var showsTouchWhenHighlighted = false
-  public var titles: [UIControlState: String] = [:]
-  public var titleColors: [UIControlState: UIColor] = [:]
-  public var titleShadowColors: [UIControlState: UIColor] = [:]
-  public var images: [UIControlState: UIImage] = [:]
-  public var backgroundImages: [UIControlState: UIImage] = [:]
-  public var attributedTitles: [UIControlState: NSAttributedString] = [:]
-  public var touchHandlers: [TouchHandlerEvent: TouchHandlerClosure] = [:]
-  
-  public init() {}
-  
-  public static func == (lhs: ButtonProps, rhs: ButtonProps) -> Bool {
-    // We can't detect whether handlers are changed
-    return false
+public extension Button {
+  public struct Props: NodeDescriptionProps, Buildable {
+    public var frame = CGRect.zero
+    public var key: String?
+    public var alpha: CGFloat = 1.0
+    
+    public var backgroundColor = UIColor.white
+    public var cornerRadius: Value = .zero
+    public var borderWidth: Value = .zero
+    public var borderColor = UIColor.clear
+    public var clipsToBounds = true
+    public var isEnabled = true
+    public var contentEdgeInsets: EdgeInsets = .zero
+    public var titleEdgeInsets: EdgeInsets = .zero
+    public var imageEdgeInsets: EdgeInsets = .zero
+    public var adjustsImageWhenHighlighted = true
+    public var adjustsImageWhenDisabled = true
+    public var showsTouchWhenHighlighted = false
+    public var titles: [UIControlState: String] = [:]
+    public var titleColors: [UIControlState: UIColor] = [:]
+    public var titleShadowColors: [UIControlState: UIColor] = [:]
+    public var images: [UIControlState: UIImage] = [:]
+    public var backgroundImages: [UIControlState: UIImage] = [:]
+    public var attributedTitles: [UIControlState: NSAttributedString] = [:]
+    public var touchHandlers: [TouchHandlerEvent: TouchHandlerClosure] = [:]
+    
+    public init() {}
+    
+    public static func == (lhs: Props, rhs: Props) -> Bool {
+      // We can't detect whether handlers are changed
+      return false
+    }
   }
 }
-
 
 public struct Button: NodeDescription {
   public typealias NativeView = NativeButton
   
-  public var props: ButtonProps
+  public var props: Props
   
-  public static func applyPropsToNativeView(props: ButtonProps,
+  public static func applyPropsToNativeView(props: Props,
                                             state: EmptyState,
                                             view: NativeButton,
                                             update: @escaping (EmptyState)->(),
@@ -110,14 +111,14 @@ public struct Button: NodeDescription {
     
   }
   
-  public static func childrenDescriptions(props: ButtonProps,
+  public static func childrenDescriptions(props: Props,
                                           state: EmptyState,
                                           update: @escaping (EmptyState)->(),
                                           dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
     return []
   }
   
-  public init(props: ButtonProps) {
+  public init(props: Props) {
     self.props = props
   }
 }

--- a/KatanaElements/Image.swift
+++ b/KatanaElements/Image.swift
@@ -9,35 +9,37 @@
 import UIKit
 import Katana
 
-public struct ImageProps: NodeDescriptionProps, Buildable {
-  public var frame = CGRect.zero
-  public var key: String?
-  public var alpha: CGFloat = 1.0
-  
-  public var backgroundColor = UIColor.white
-  public var cornerRadius: Value = .zero
-  public var borderWidth: Value = .zero
-  public var borderColor = UIColor.clear
-  public var clipsToBounds = true
-  public var isUserInteractionEnabled = false
-  public var image: UIImage? = nil
-  public var tintColor: UIColor = .clear
-  
-  public init() {}
-  
-  public static func == (lhs: ImageProps, rhs: ImageProps) -> Bool {
-    return
-      lhs.frame == rhs.frame &&
-      lhs.key == rhs.key &&
-      lhs.alpha == rhs.alpha &&
-      lhs.backgroundColor == rhs.backgroundColor &&
-      lhs.cornerRadius == rhs.cornerRadius &&
-      lhs.borderWidth == rhs.borderWidth &&
-      lhs.borderColor == rhs.borderColor &&
-      lhs.clipsToBounds == rhs.clipsToBounds &&
-      lhs.isUserInteractionEnabled == rhs.isUserInteractionEnabled &&
-      lhs.image == rhs.image &&
-      lhs.tintColor == rhs.tintColor
+public extension Image {
+  public struct Props: NodeDescriptionProps, Buildable {
+    public var frame = CGRect.zero
+    public var key: String?
+    public var alpha: CGFloat = 1.0
+    
+    public var backgroundColor = UIColor.white
+    public var cornerRadius: Value = .zero
+    public var borderWidth: Value = .zero
+    public var borderColor = UIColor.clear
+    public var clipsToBounds = true
+    public var isUserInteractionEnabled = false
+    public var image: UIImage? = nil
+    public var tintColor: UIColor = .clear
+    
+    public init() {}
+    
+    public static func == (lhs: Props, rhs: Props) -> Bool {
+      return
+        lhs.frame == rhs.frame &&
+        lhs.key == rhs.key &&
+        lhs.alpha == rhs.alpha &&
+        lhs.backgroundColor == rhs.backgroundColor &&
+        lhs.cornerRadius == rhs.cornerRadius &&
+        lhs.borderWidth == rhs.borderWidth &&
+        lhs.borderColor == rhs.borderColor &&
+        lhs.clipsToBounds == rhs.clipsToBounds &&
+        lhs.isUserInteractionEnabled == rhs.isUserInteractionEnabled &&
+        lhs.image == rhs.image &&
+        lhs.tintColor == rhs.tintColor
+    }
   }
 }
 
@@ -45,9 +47,9 @@ public struct ImageProps: NodeDescriptionProps, Buildable {
 public struct Image: NodeDescription {
   public typealias NativeView = UIImageView
 
-  public var props: ImageProps
+  public var props: Props
   
-  public static func applyPropsToNativeView(props: ImageProps,
+  public static func applyPropsToNativeView(props: Props,
                                             state: EmptyState,
                                             view: UIImageView,
                                             update: @escaping (EmptyState)->(),
@@ -65,14 +67,14 @@ public struct Image: NodeDescription {
     view.tintColor = props.tintColor
   }
   
-  public static func childrenDescriptions(props: ImageProps,
+  public static func childrenDescriptions(props: Props,
                                           state: EmptyState,
                                           update: @escaping (EmptyState)->(),
                                           dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
     return []
   }
   
-  public init(props: ImageProps) {
+  public init(props: Props) {
     self.props = props
   }
 }

--- a/KatanaElements/Label.swift
+++ b/KatanaElements/Label.swift
@@ -9,55 +9,57 @@
 import UIKit
 import Katana
 
-public struct LabelProps: NodeDescriptionProps, Buildable {
-  public var frame = CGRect.zero
-  public var key: String?
-  public var alpha: CGFloat = 1.0
-  
-  public var backgroundColor = UIColor.white
-  public var cornerRadius: Value = .zero
-  public var borderWidth: Value = .zero
-  public var borderColor = UIColor.clear
-  public var clipsToBounds = true
-  public var isUserInteractionEnabled = false
-  public var text: NSAttributedString?
-  public var textAlignment: NSTextAlignment = .left
-  public var lineBreakMode: NSLineBreakMode = .byClipping
-  public var numberOfLines: Int = 1
-  public var adjustsFontSizeToFitWidth: Bool = true
-  public var allowsDefaultTighteningForTruncation: Bool = true
-  public var minimumScaleFactor: CGFloat = 0.10
-  
-  public static func == (lhs: LabelProps, rhs: LabelProps) -> Bool {
-    return
-      lhs.frame == rhs.frame &&
-      lhs.key == rhs.key &&
-      lhs.alpha == rhs.alpha &&
-      lhs.backgroundColor == rhs.backgroundColor &&
-      lhs.cornerRadius == rhs.cornerRadius &&
-      lhs.borderWidth == rhs.borderWidth &&
-      lhs.borderColor == rhs.borderColor &&
-      lhs.clipsToBounds == rhs.clipsToBounds &&
-      lhs.isUserInteractionEnabled == rhs.isUserInteractionEnabled &&
-      lhs.text == rhs.text &&
-      lhs.textAlignment == rhs.textAlignment &&
-      lhs.lineBreakMode == rhs.lineBreakMode &&
-      lhs.numberOfLines == rhs.numberOfLines &&
-      lhs.adjustsFontSizeToFitWidth == rhs.adjustsFontSizeToFitWidth &&
-      lhs.allowsDefaultTighteningForTruncation == rhs.allowsDefaultTighteningForTruncation &&
-      lhs.minimumScaleFactor == rhs.minimumScaleFactor
+public extension Label {
+  public struct Props: NodeDescriptionProps, Buildable {
+    public var frame = CGRect.zero
+    public var key: String?
+    public var alpha: CGFloat = 1.0
+    
+    public var backgroundColor = UIColor.white
+    public var cornerRadius: Value = .zero
+    public var borderWidth: Value = .zero
+    public var borderColor = UIColor.clear
+    public var clipsToBounds = true
+    public var isUserInteractionEnabled = false
+    public var text: NSAttributedString?
+    public var textAlignment: NSTextAlignment = .left
+    public var lineBreakMode: NSLineBreakMode = .byClipping
+    public var numberOfLines: Int = 1
+    public var adjustsFontSizeToFitWidth: Bool = true
+    public var allowsDefaultTighteningForTruncation: Bool = true
+    public var minimumScaleFactor: CGFloat = 0.10
+    
+    public static func == (lhs: Props, rhs: Props) -> Bool {
+      return
+        lhs.frame == rhs.frame &&
+          lhs.key == rhs.key &&
+          lhs.alpha == rhs.alpha &&
+          lhs.backgroundColor == rhs.backgroundColor &&
+          lhs.cornerRadius == rhs.cornerRadius &&
+          lhs.borderWidth == rhs.borderWidth &&
+          lhs.borderColor == rhs.borderColor &&
+          lhs.clipsToBounds == rhs.clipsToBounds &&
+          lhs.isUserInteractionEnabled == rhs.isUserInteractionEnabled &&
+          lhs.text == rhs.text &&
+          lhs.textAlignment == rhs.textAlignment &&
+          lhs.lineBreakMode == rhs.lineBreakMode &&
+          lhs.numberOfLines == rhs.numberOfLines &&
+          lhs.adjustsFontSizeToFitWidth == rhs.adjustsFontSizeToFitWidth &&
+          lhs.allowsDefaultTighteningForTruncation == rhs.allowsDefaultTighteningForTruncation &&
+          lhs.minimumScaleFactor == rhs.minimumScaleFactor
+    }
+    
+    public init() {}
   }
-  
-  public init() {}
 }
 
 
 public struct Label: NodeDescription {
   public typealias NativeView = UILabel
 
-  public var props: LabelProps
+  public var props: Props
   
-  public static func applyPropsToNativeView(props: LabelProps,
+  public static func applyPropsToNativeView(props: Props,
                                             state: EmptyState,
                                             view: UILabel,
                                             update: @escaping (EmptyState)->(),
@@ -83,14 +85,14 @@ public struct Label: NodeDescription {
     }
   }
   
-  public static func childrenDescriptions(props: LabelProps,
+  public static func childrenDescriptions(props: Props,
                                           state: EmptyState,
                                           update: @escaping (EmptyState)->(),
                                           dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
     return []
   }
   
-  public init(props: LabelProps) {
+  public init(props: Props) {
     self.props = props
   }
 }

--- a/KatanaElements/Table/Table.swift
+++ b/KatanaElements/Table/Table.swift
@@ -10,44 +10,46 @@ import Foundation
 import UIKit
 import Katana
 
-public struct TableProps: NodeDescriptionProps, Buildable {
-  public var frame = CGRect.zero
-  public var key: String?
-  public var alpha: CGFloat = 1.0
-  
-  public var delegate: TableDelegate = EmptyTableDelegate()
-  public var backgroundColor = UIColor.white
-  public var cornerRadius: CGFloat = 0.0
-  public var borderWidth: CGFloat = 0.0
-  public var borderColor = UIColor.clear
-  public var clipsToBounds = true
-  
-  public init() {}
-  
-  public static func == (lhs: TableProps, rhs: TableProps) -> Bool {
-    return
-      lhs.frame == rhs.frame &&
-      lhs.key == rhs.key &&
-      lhs.alpha == rhs.alpha &&
-      lhs.backgroundColor == rhs.backgroundColor &&
-      lhs.cornerRadius == rhs.cornerRadius &&
-      lhs.borderWidth == rhs.borderWidth &&
-      lhs.borderColor == rhs.borderColor &&
-      lhs.clipsToBounds == rhs.clipsToBounds &&
-      lhs.delegate.isEqual(to: rhs.delegate)
+public extension Table {
+  public struct Props: NodeDescriptionProps, Buildable {
+    public var frame = CGRect.zero
+    public var key: String?
+    public var alpha: CGFloat = 1.0
+    
+    public var delegate: TableDelegate = EmptyTableDelegate()
+    public var backgroundColor = UIColor.white
+    public var cornerRadius: CGFloat = 0.0
+    public var borderWidth: CGFloat = 0.0
+    public var borderColor = UIColor.clear
+    public var clipsToBounds = true
+    
+    public init() {}
+    
+    public static func == (lhs: Props, rhs: Props) -> Bool {
+      return
+        lhs.frame == rhs.frame &&
+          lhs.key == rhs.key &&
+          lhs.alpha == rhs.alpha &&
+          lhs.backgroundColor == rhs.backgroundColor &&
+          lhs.cornerRadius == rhs.cornerRadius &&
+          lhs.borderWidth == rhs.borderWidth &&
+          lhs.borderColor == rhs.borderColor &&
+          lhs.clipsToBounds == rhs.clipsToBounds &&
+          lhs.delegate.isEqual(to: rhs.delegate)
+    }
   }
 }
 
 public struct Table: NodeDescription {
   public typealias NativeView = NativeTable
   
-  public var props: TableProps
+  public var props: Props
   
-  public init(props: TableProps) {
+  public init(props: Props) {
     self.props = props
   }
   
-  public static func applyPropsToNativeView(props: TableProps,
+  public static func applyPropsToNativeView(props: Props,
                                             state: EmptyState,
                                             view: NativeTable,
                                             update: @escaping (EmptyState)->(),
@@ -64,7 +66,7 @@ public struct Table: NodeDescription {
   }
   
   
-  public static func childrenDescriptions(props: TableProps,
+  public static func childrenDescriptions(props: Props,
                             state: EmptyState,
                             update: @escaping (EmptyState)->(),
                             dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {

--- a/KatanaElements/TouchHandler/TouchHandler.swift
+++ b/KatanaElements/TouchHandler/TouchHandler.swift
@@ -11,29 +11,31 @@ import Katana
 
 public typealias TouchHandlerClosure = () -> ()
 
-public struct TouchHandlerProps: NodeDescriptionProps, Childrenable, Buildable {
-  public var frame = CGRect.zero
-  public var key: String?
-  public var alpha: CGFloat = 1.0
-  
-  public var children: [AnyNodeDescription] = []
-  public var handlers: [TouchHandlerEvent: TouchHandlerClosure]?
-  public var hitTestInsets: UIEdgeInsets = .zero
-  
-  public init() {}
-  
-  public static func == (lhs: TouchHandlerProps, rhs: TouchHandlerProps) -> Bool {
-    // always re render, we haven't found a decent way to compare handlers so far
-    return false
+public extension TouchHandler {
+  public struct Props: NodeDescriptionProps, Childrenable, Buildable {
+    public var frame = CGRect.zero
+    public var key: String?
+    public var alpha: CGFloat = 1.0
+    
+    public var children: [AnyNodeDescription] = []
+    public var handlers: [TouchHandlerEvent: TouchHandlerClosure]?
+    public var hitTestInsets: UIEdgeInsets = .zero
+    
+    public init() {}
+    
+    public static func == (lhs: Props, rhs: Props) -> Bool {
+      // always re render, we haven't found a decent way to compare handlers so far
+      return false
+    }
   }
 }
 
 public struct TouchHandler: NodeDescription, NodeDescriptionWithChildren {
   public typealias NativeView = NativeTouchHandler
   
-  public var props: TouchHandlerProps
+  public var props: Props
   
-  public static func applyPropsToNativeView(props: TouchHandlerProps,
+  public static func applyPropsToNativeView(props: Props,
                                             state: EmptyState,
                                             view: NativeTouchHandler,
                                             update: @escaping (EmptyState)->(),
@@ -44,7 +46,7 @@ public struct TouchHandler: NodeDescription, NodeDescriptionWithChildren {
     view.hitTestInsets = props.hitTestInsets
   }
 
-  public static func childrenDescriptions(props: TouchHandlerProps,
+  public static func childrenDescriptions(props: Props,
                                           state: EmptyState,
                                           update: @escaping (EmptyState)->(),
                                           dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
@@ -52,11 +54,11 @@ public struct TouchHandler: NodeDescription, NodeDescriptionWithChildren {
     return props.children
   }
   
-  public init(props: TouchHandlerProps) {
+  public init(props: Props) {
     self.props = props
   }
   
-  public init(props: TouchHandlerProps, _ children: () -> [AnyNodeDescription]) {
+  public init(props: Props, _ children: () -> [AnyNodeDescription]) {
     self.props = props
     self.props.children = children()
   }

--- a/KatanaElements/View.swift
+++ b/KatanaElements/View.swift
@@ -9,47 +9,47 @@
 import UIKit
 import Katana
 
-public struct ViewProps: NodeDescriptionProps, Childrenable, Buildable {
-  public var frame = CGRect.zero
-  public var key: String?
-  public var alpha: CGFloat = 1.0
-
-  public var children: [AnyNodeDescription] = []
-  
-  public var backgroundColor = UIColor.white
-  public var cornerRadius: Value = .zero
-  public var borderWidth: Value = .zero
-  public var borderColor = UIColor.clear
-  public var clipsToBounds = false
-  public var isUserInteractionEnabled = false
- 
-  public init() {}
-
-  public static func == (lhs: ViewProps, rhs: ViewProps) -> Bool {
-    if lhs.children.count + rhs.children.count > 0 {
-      // Heuristic, we always rerender when there is at least 1 child
-      return false
-    }
+public extension View {
+  public struct Props: NodeDescriptionProps, Childrenable, Buildable {
+    public var frame = CGRect.zero
+    public var key: String?
+    public var alpha: CGFloat = 1.0
     
-    return
-      lhs.frame == rhs.frame &&
-      lhs.key == rhs.key &&
-      lhs.alpha == rhs.alpha &&
-      lhs.backgroundColor == rhs.backgroundColor &&
-      lhs.cornerRadius == rhs.cornerRadius &&
-      lhs.borderWidth == rhs.borderWidth &&
-      lhs.borderColor == rhs.borderColor &&
-      lhs.clipsToBounds == rhs.clipsToBounds &&
-      lhs.isUserInteractionEnabled == rhs.isUserInteractionEnabled
+    public var children: [AnyNodeDescription] = []
+    
+    public var backgroundColor = UIColor.white
+    public var cornerRadius: Value = .zero
+    public var borderWidth: Value = .zero
+    public var borderColor = UIColor.clear
+    public var clipsToBounds = false
+    public var isUserInteractionEnabled = false
+    
+    public init() {}
+    
+    public static func == (lhs: Props, rhs: Props) -> Bool {
+      if lhs.children.count + rhs.children.count > 0 {
+        // Heuristic, we always rerender when there is at least 1 child
+        return false
+      }
+      
+      return
+        lhs.frame == rhs.frame &&
+          lhs.key == rhs.key &&
+          lhs.alpha == rhs.alpha &&
+          lhs.backgroundColor == rhs.backgroundColor &&
+          lhs.cornerRadius == rhs.cornerRadius &&
+          lhs.borderWidth == rhs.borderWidth &&
+          lhs.borderColor == rhs.borderColor &&
+          lhs.clipsToBounds == rhs.clipsToBounds &&
+          lhs.isUserInteractionEnabled == rhs.isUserInteractionEnabled
+    }
   }
 }
 
-
 public struct View: NodeDescription, NodeDescriptionWithChildren {
-  
-  public var props: ViewProps
+  public var props: Props
 
-  public static func applyPropsToNativeView(props: ViewProps,
+  public static func applyPropsToNativeView(props: Props,
                                             state: EmptyState,
                                             view: UIView,
                                             update: @escaping (EmptyState)->(),
@@ -65,18 +65,18 @@ public struct View: NodeDescription, NodeDescriptionWithChildren {
     view.isUserInteractionEnabled = props.isUserInteractionEnabled
   }
   
-  public static func childrenDescriptions(props: ViewProps,
+  public static func childrenDescriptions(props: Props,
                                           state: EmptyState,
                                           update: @escaping (EmptyState)->(),
                                           dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
     return props.children
   }
   
-  public init(props: ViewProps) {
+  public init(props: Props) {
     self.props = props
   }
   
-  public init(props: ViewProps, _ children: () -> [AnyNodeDescription]) {
+  public init(props: Props, _ children: () -> [AnyNodeDescription]) {
     self.props = props
     self.props.children = children()
   }


### PR DESCRIPTION
This PR implements the namespacing conventions for Katana Elements

For example we changed from
```swift
struct ButtonProps {}
struct Button {}
```

to 
```swift
struct Button {}
extension Button {
 struct Props {}
}
```