### PR TITLE
Fix the access to the renderer from every node

### DIFF
--- a/Katana/Core/Node/AnyNode.swift
+++ b/Katana/Core/Node/AnyNode.swift
@@ -29,7 +29,7 @@ public protocol AnyNode: class {
   /**
    The renderer of the node. This is a computed variable that traverses the tree up to the root node and returns `root.renderer`
    */
-  var renderer: Renderer? { get }
+  var renderer: Renderer { get }
   
   /**
    Updates the node with a new description. Invoking this method will cause an update of the piece of the UI managed by the node

--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -66,9 +66,11 @@ public class Node<Description: NodeDescription> {
   public fileprivate(set) weak var parent: AnyNode?
   
   /**
-   The renderer of the node. This is a computed variable that traverses the tree up to the root node and returns root.renderer
+   The renderer of the node. This is a private variable where we store the reference to the Renderer object. Please note that this will contain the Renderer only for the first Node of the hierarchy, for the others it will be nil. To retrieve the Renderer from every Node just use the renderer computed variable that will traverse the nodes tree up to the root node and returns root._renderer
    */
-  public fileprivate(set) weak var renderer: Renderer?
+  fileprivate weak var _renderer: Renderer?
+  
+  
   
   /// The array of managed children of the node
   public var managedChildren: [AnyNode] = []
@@ -117,7 +119,7 @@ public class Node<Description: NodeDescription> {
     self.description = description
     self.state = Description.StateType.init()
     self.parent = parent
-    self.renderer = renderer
+    self._renderer = renderer
     
     self.description.props = self.updatedPropsWithConnect(description: description, props: self.description.props)
     
@@ -578,3 +580,14 @@ extension Node {
 }
 
 extension Node : InternalAnyNode {}
+
+// MARK: Renderer Connection
+extension Node {
+  /**
+   The renderer of the node. This is a computed variable that traverses the tree up to the root node and returns root.renderer
+   */
+  public var renderer: Renderer {
+    guard self._renderer == nil else { return self._renderer! }
+    return self.parent!.renderer
+  }
+}

--- a/Katana/Core/StoreConnection/Renderer.swift
+++ b/Katana/Core/StoreConnection/Renderer.swift
@@ -114,15 +114,3 @@ open class Renderer {
     self.unsubscribe?()
   }
 }
-
-
-public extension AnyNode {
-  /// traverses the nodes hierarchy up to the root node to get the `root.renderer`
-  public var renderer: Renderer {
-    var node: AnyNode = self
-    while node.parent != nil {
-      node = node.parent!
-    }
-    return node.renderer!
-  }
-}


### PR DESCRIPTION
This pull request fix the access to the renderer from every node.
In the previous implementation the `renderer` computed property of the `AnyNode` protocol was erased by the `renderer` variable of the `Node` class.

Solution: store the reference of the renderer inside a private `_renderer: Renderer?` variable in `Node`, expose a computed property `renderer: Renderer` from `AnyNode`.

```
public class Renderer {
}

public class Node<T> {
  private var _renderer: Renderer?
  public var parent: AnyNode?
  
  public var renderer: Renderer {
    guard self._renderer == nil else { return self._renderer! }
    return self.parent!.renderer
  }
}

public protocol AnyNode: class {
  var renderer: Renderer { get }
  var parent: AnyNode? { get }
}

protocol InternalAnyNode: AnyNode {}

extension Node: InternalAnyNode {}
```