### PR TITLE
Possible Fix For #67 - Change referenceSize static var to func

### DIFF
--- a/Demo/UI/CounterScreen.swift
+++ b/Demo/UI/CounterScreen.swift
@@ -33,9 +33,7 @@ struct CounterScreen: ConnectedNodeDescription, PlasticNodeDescription, PlasticR
   
   var props: PropsType
   
-  static func referenceSize(props: PropsType, state: StateType) -> CGSize {
-    return CGSize(width: 640, height: 960)
-  }
+  static var referenceSize =  CGSize(width: 640, height: 960)
 
   public static func childrenDescriptions(props: PropsType,
                                           state: StateType,

--- a/Demo/UI/CounterScreen.swift
+++ b/Demo/UI/CounterScreen.swift
@@ -33,8 +33,10 @@ struct CounterScreen: ConnectedNodeDescription, PlasticNodeDescription, PlasticR
   
   var props: PropsType
   
-  static var referenceSize = CGSize(width: 640, height: 960)
-  
+  static func referenceSize(props: PropsType, state: StateType) -> CGSize {
+    return CGSize(width: 640, height: 960)
+  }
+
   public static func childrenDescriptions(props: PropsType,
                                           state: StateType,
                                           update: @escaping (StateType) -> (),

--- a/Katana/Core/Node/AnyNode.swift
+++ b/Katana/Core/Node/AnyNode.swift
@@ -17,6 +17,9 @@ public protocol AnyNode: class {
   /// Type erasure for the `NodeDescription` that the node holds
   var anyDescription: AnyNodeDescription { get }
   
+  /// Type erasure for the `State` that the node holds
+  var anyState: AnyNodeDescriptionState { get }
+
   /// Children nodes of the node
   var children: [AnyNode]! { get }
   

--- a/Katana/Core/Node/Node+AnyNode.swift
+++ b/Katana/Core/Node/Node+AnyNode.swift
@@ -20,6 +20,16 @@ extension Node: AnyNode {
     }
   }
   
+  /**
+   Implementation of the AnyNode protocol.
+
+   - seeAlso: `AnyNode`
+   */
+  public var anyState: AnyNodeDescriptionState {
+    get {
+      return self.state
+    }
+  }
   
   /**
    Implementation of the AnyNode protocol.

--- a/Katana/Core/NodeDescription/NodeDescription.swift
+++ b/Katana/Core/NodeDescription/NodeDescription.swift
@@ -8,13 +8,16 @@
 
 import UIKit
 
+/// Type Erasure for `NodeDescriptionProps`
+public protocol AnyNodeDescriptionState {}
+
 /**
  Protocol that is used for structs that represent the state of a `Node`.
  
  This protocol requires instances to be equatable. Katana uses this requirement to
  avoid to update the UI if the state (and the props) are not changed.
 */
-public protocol NodeDescriptionState: Equatable {
+public protocol NodeDescriptionState: Equatable, AnyNodeDescriptionState {
   /**
    Default init for the state. It is used by Katana to create the initial state of a `Node`.
    You should initialise the state with meaningful default values.

--- a/Katana/Plastic/PlasticNode.swift
+++ b/Katana/Plastic/PlasticNode.swift
@@ -113,11 +113,11 @@ public extension AnyNode {
   */
   public var plasticMultipler: CGFloat {
     
-    guard let description = self.anyDescription as? PlasticReferenceSizeable else {
+    guard let description = self.anyDescription as? AnyPlasticReferenceSizeable else {
       return self.parent?.plasticMultipler ?? 0.0
     }
     
-    let referenceSize = type(of: description).referenceSize
+    let referenceSize = type(of: description).anyReferenceSize(props:self.anyDescription.anyProps, state:self.anyState)
     let currentSize = self.anyDescription.anyProps.frame
     
     let widthRatio = currentSize.width / referenceSize.width

--- a/Katana/Plastic/PlasticReferenceSizeable.swift
+++ b/Katana/Plastic/PlasticReferenceSizeable.swift
@@ -8,6 +8,11 @@
 
 import UIKit
 
+/// Type Erasure for `PlasticReferenceSizeable`
+public protocol AnyPlasticReferenceSizeable {
+  static func anyReferenceSize(props: Any, state: Any) -> CGSize
+}
+
 /**
  Protocol that `NodeDescription` implementations can adopt to provide a reference size.
  
@@ -22,8 +27,16 @@ import UIKit
  
  - the Plastic multiplier is the minimum of the two
 */
-public protocol PlasticReferenceSizeable {
-  
+public protocol PlasticReferenceSizeable: AnyPlasticReferenceSizeable, PlasticNodeDescription {
   /// the reference size of the `NodeDescription`
-  static var referenceSize: CGSize {get}
+  static func referenceSize(props: PropsType, state: StateType) -> CGSize
+}
+
+public extension PlasticReferenceSizeable {
+  static func anyReferenceSize(props: Any, state: Any) -> CGSize {
+    if let p = props as? PropsType, let s = state as? StateType {
+      return referenceSize(props: p, state: s)
+    }
+    return .zero
+  }
 }

--- a/Katana/Plastic/PlasticReferenceSizeable.swift
+++ b/Katana/Plastic/PlasticReferenceSizeable.swift
@@ -15,28 +15,58 @@ public protocol AnyPlasticReferenceSizeable {
 
 /**
  Protocol that `NodeDescription` implementations can adopt to provide a reference size.
- 
- Reference Size is used to calculate the Plastic multiplier. For a given node, the multiplier
- is calculated in the following way:
- 
- - find the closest ancestor in the nodes tree
- 
- - calculate the height multiplier: `ancestor.size.height / ancestor.description.referenceSize.height`
- 
- - calculate the width multiplier: `ancestor.size.width / ancestor.description.referenceSize.width`
- 
- - the Plastic multiplier is the minimum of the two
+
+ If you need to return a simple value that doesn't depend on props and state, adopt `PlasticReferenceSizeable`
+ and just define the `referenceSize` static var.
+
+  - seeAlso: `PlasticReferenceSizeable`
 */
-public protocol PlasticReferenceSizeable: AnyPlasticReferenceSizeable, PlasticNodeDescription {
+public protocol PlasticExtendedReferenceSizeable: AnyPlasticReferenceSizeable, PlasticNodeDescription {
   /// the reference size of the `NodeDescription`
   static func referenceSize(props: PropsType, state: StateType) -> CGSize
 }
 
-public extension PlasticReferenceSizeable {
+/**
+ Protocol that `NodeDescription` implementations can adopt to provide a reference size.
+ If you want to return different values depending on props/state, you can adopt the `PlasticExtendedReferenceSizeable` protocol.
+
+ Reference Size is used to calculate the Plastic multiplier. For a given node, the multiplier
+ is calculated in the following way:
+
+ - find the closest ancestor in the nodes tree
+
+ - calculate the height multiplier: `ancestor.size.height / ancestor.description.referenceSize.height`
+
+ - calculate the width multiplier: `ancestor.size.width / ancestor.description.referenceSize.width`
+
+ - the Plastic multiplier is the minimum of the two
+
+ - seeAlso: `PlasticExtendedReferenceSizeable`
+*/
+public protocol PlasticReferenceSizeable: PlasticExtendedReferenceSizeable {
+  /// The referenceSize of the `NodeDescription`
+  static var referenceSize: CGSize { get }
+}
+
+public extension PlasticExtendedReferenceSizeable {
+  /**
+   Implementation of the `PlasticExtendedReferenceSizeable` protocol.
+
+   - seeAlso: `PlasticExtendedReferenceSizeable`
+  */
   static func anyReferenceSize(props: Any, state: Any) -> CGSize {
-    if let p = props as? PropsType, let s = state as? StateType {
-      return referenceSize(props: p, state: s)
-    }
-    return .zero
+    let p = props as! PropsType, s = state as! StateType
+    return referenceSize(props: p, state: s)
+  }
+}
+
+public extension PlasticReferenceSizeable {
+  /**
+   Implementation of the `PlasticReferenceSizeable` protocol.
+
+   - seeAlso: `PlasticReferenceSizeable`
+  */
+  static func referenceSize(props: PropsType, state: StateType) -> CGSize {
+    return referenceSize
   }
 }


### PR DESCRIPTION
**Why**
This is a possible attempt to fix the issue #67.
It gives developers maximum flexibility while retaining a simple interface, which is the same of the `PlasticNodeDescription`'s `layout` func. 

This PR doesn't introduce any BC.

**Changes**
- Add `PlasticExtendedReferenceSizeable` protocol, which contains a `referenceSize` static func with props and state parameters, that can be implemented in place of the `referenceSize` static var. `PlasticReferenceSizeable` protocol is kept `as is`.

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [ ] Ensure that all the examples (as well as the demo) work properly
