### PR TITLE
Update SyncAction.swift documentation

### DIFF
--- a/Katana/Store/SyncAction.swift
+++ b/Katana/Store/SyncAction.swift
@@ -27,7 +27,7 @@ import Foundation
  }
  
  extension AppSyncAction {
-  func updateState(currentState: State) -> State {
+  func updatedState(currentState: State) -> State {
     guard var state = currentState as? AppState else {
       fatalError("Something went wrong")
     }


### PR DESCRIPTION
This is an error, probably due to the old signature of the `updatedState` method from a previous version of Katana.