### PR TITLE
Lifecycle APIs

### DIFF
--- a/Katana.xcodeproj/project.pbxproj
+++ b/Katana.xcodeproj/project.pbxproj
@@ -178,6 +178,8 @@
 		A17AF9CD1DC9F5EF00F6076E /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17AF9CB1DC9F5EF00F6076E /* View.swift */; };
 		A17EB5D21DD09B39009A5D8F /* ChildrenAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB5D11DD09B39009A5D8F /* ChildrenAnimations.swift */; };
 		A17EB5D41DD09E02009A5D8F /* AnimationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB5D31DD09E02009A5D8F /* AnimationUtils.swift */; };
+		A19385481E0D1F3C00F436D6 /* NodeDescriptionLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19385461E0D1F2100F436D6 /* NodeDescriptionLifecycleTests.swift */; };
+		A19385491E0D1F3E00F436D6 /* NodeDescriptionLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19385461E0D1F2100F436D6 /* NodeDescriptionLifecycleTests.swift */; };
 		A1C9C1C31DD32D570067F8E0 /* InternalNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C9C1C21DD32D570067F8E0 /* InternalNode.swift */; };
 		A1C9C1C61DD337710067F8E0 /* ChildrenAnimationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C9C1C51DD337710067F8E0 /* ChildrenAnimationsTests.swift */; };
 		A1C9C1C81DD339D00067F8E0 /* AnimationUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C9C1C71DD339D00067F8E0 /* AnimationUtilsTests.swift */; };
@@ -377,6 +379,7 @@
 		A17AF9CB1DC9F5EF00F6076E /* View.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		A17EB5D11DD09B39009A5D8F /* ChildrenAnimations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChildrenAnimations.swift; sourceTree = "<group>"; };
 		A17EB5D31DD09E02009A5D8F /* AnimationUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationUtils.swift; sourceTree = "<group>"; };
+		A19385461E0D1F2100F436D6 /* NodeDescriptionLifecycleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeDescriptionLifecycleTests.swift; sourceTree = "<group>"; };
 		A1C9C1C21DD32D570067F8E0 /* InternalNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalNode.swift; sourceTree = "<group>"; };
 		A1C9C1C51DD337710067F8E0 /* ChildrenAnimationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChildrenAnimationsTests.swift; sourceTree = "<group>"; };
 		A1C9C1C71DD339D00067F8E0 /* AnimationUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationUtilsTests.swift; sourceTree = "<group>"; };
@@ -756,6 +759,7 @@
 				81911D9D1D7D916B00123C54 /* NodeDescriptionTest.swift */,
 				81911D9E1D7D916B00123C54 /* NodeTest.swift */,
 				81911D9F1D7D916B00123C54 /* RenderContainersTest.swift */,
+				A19385461E0D1F2100F436D6 /* NodeDescriptionLifecycleTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1418,6 +1422,7 @@
 				65BF2EFB1DE8301E00441784 /* PlasticNodeTests.swift in Sources */,
 				65BF2EFC1DE8301E00441784 /* MiddlewareTests.swift in Sources */,
 				65BF2EFD1DE8301E00441784 /* StoreTests.swift in Sources */,
+				A19385491E0D1F3E00F436D6 /* NodeDescriptionLifecycleTests.swift in Sources */,
 				65BF2EFE1DE8301E00441784 /* SyncActionTests.swift in Sources */,
 				65BF2EFF1DE8301E00441784 /* AsyncActionTests.swift in Sources */,
 				65BF2F001DE8301E00441784 /* SideEffectTests.swift in Sources */,
@@ -1525,6 +1530,7 @@
 				A17AF9CC1DC9F5EF00F6076E /* Image.swift in Sources */,
 				A1C9C1C81DD339D00067F8E0 /* AnimationUtilsTests.swift in Sources */,
 				81911DC41D7D916B00123C54 /* StoreTests.swift in Sources */,
+				A19385481E0D1F3C00F436D6 /* NodeDescriptionLifecycleTests.swift in Sources */,
 				81911DBE1D7D916B00123C54 /* PlasticConvenienceLayoutTests.swift in Sources */,
 				81911DC01D7D916B00123C54 /* PlasticNodeTests.swift in Sources */,
 				81911DB91D7D916B00123C54 /* Collections.swift in Sources */,

--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -403,11 +403,25 @@ extension Node {
       return
     }
     
+    // invoke the proper lifecycle hook
+    var newState = state
+    
+    let update: (Description.StateType) -> () = { newState = $0 }
+    let dispatch =  self.renderer?.store?.dispatch ?? { fatalError("\($0) cannot be dispatched. Store not avaiable.") }
+    
+    Description.descriptionWillReceiveProps(
+      state: state,
+      currentProps: self.description.props,
+      nextProps: description.props,
+      dispatch: dispatch,
+      update: update
+    )
+    
     // update the internal state
     let currentState = self.state
     let currentDescription = self.description
     self.description = description
-    self.state = state
+    self.state = newState
     
     // calculate new children
     let newChildrenDescriptions = self.processedChildrenDescriptionsBeforeDraw(

--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -189,6 +189,9 @@ extension Node {
     }
     
     
+    let dispatch =  self.renderer?.store?.dispatch ?? { fatalError("\($0) cannot be dispatched. Store not avaiable.") }
+    Description.didMount(props: self.description.props, dispatch: dispatch)
+    
     children.forEach { child in
       let child = child as! InternalAnyNode
       child.render(in: self.container!)

--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -152,6 +152,11 @@ public class Node<Description: NodeDescription> {
     // NOTE: this method is here because Swift doesn't support override of extension methods yet
     return children
   }
+  
+  deinit {
+    let dispatch =  self.renderer?.store?.dispatch ?? { fatalError("\($0) cannot be dispatched. Store not avaiable.") }
+    Description.didUnmount(props: self.description.props, dispatch: dispatch)
+  }
 }
 
 

--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -76,6 +76,10 @@ public class Node<Description: NodeDescription> {
    */
   fileprivate weak var myRenderer: Renderer?
   
+  fileprivate var storeDispatch: StoreDispatch {
+    return self.renderer?.store?.dispatch ?? { fatalError("\($0) cannot be dispatched. Store not avaiable.") }
+  }
+  
   
   
   /// The array of managed children of the node
@@ -154,8 +158,7 @@ public class Node<Description: NodeDescription> {
   }
   
   deinit {
-    let dispatch =  self.renderer?.store?.dispatch ?? { fatalError("\($0) cannot be dispatched. Store not avaiable.") }
-    Description.didUnmount(props: self.description.props, dispatch: dispatch)
+    Description.didUnmount(props: self.description.props, dispatch: self.storeDispatch)
   }
 }
 
@@ -194,8 +197,7 @@ extension Node {
     }
     
     
-    let dispatch =  self.renderer?.store?.dispatch ?? { fatalError("\($0) cannot be dispatched. Store not avaiable.") }
-    Description.didMount(props: self.description.props, dispatch: dispatch)
+    Description.didMount(props: self.description.props, dispatch: self.storeDispatch)
     
     children.forEach { child in
       let child = child as! InternalAnyNode
@@ -332,12 +334,10 @@ extension Node {
       }
     }
     
-    let dispatch =  self.renderer?.store?.dispatch ?? { fatalError("\($0) cannot be dispatched. Store not avaiable.") }
-    
     return type(of: description).childrenDescriptions(props: self.description.props,
                                                       state: self.state,
                                                       update: update,
-                                                      dispatch: dispatch)
+                                                      dispatch: self.storeDispatch)
   }
   
   /**
@@ -407,13 +407,12 @@ extension Node {
     var newState = state
     
     let update: (Description.StateType) -> () = { newState = $0 }
-    let dispatch =  self.renderer?.store?.dispatch ?? { fatalError("\($0) cannot be dispatched. Store not avaiable.") }
     
     Description.descriptionWillReceiveProps(
       state: state,
       currentProps: self.description.props,
       nextProps: description.props,
-      dispatch: dispatch,
+      dispatch: self.storeDispatch,
       update: update
     )
     

--- a/Katana/Core/NodeDescription/NodeDescription.swift
+++ b/Katana/Core/NodeDescription/NodeDescription.swift
@@ -243,6 +243,14 @@ public protocol NodeDescription: AnyNodeDescription {
    - parameter dispastch: the store dispatch function
   */
   static func didMount(props: PropsType, dispatch: StoreDispatch)
+  
+  /**
+   This method is invoked just after the backing node is removed from the view's hierarchy.
+   
+   - parameter props:     the final props of the description
+   - parameter dispastch: the store dispatch function
+   */
+  static func didUnmount(props: PropsType, dispatch: StoreDispatch)
 }
 
 public extension NodeDescription {
@@ -272,9 +280,11 @@ public extension NodeDescription {
     // do nothing, which means no animations
   }
   
-  public static func didMount(props: PropsType, dispatch: StoreDispatch) {
-    // nothing
-  }
+  /// The default implementation does nothing
+  public static func didMount(props: PropsType, dispatch: StoreDispatch) {}
+  
+  /// The default implementation does nothing
+  public static func didUnmount(props: PropsType, dispatch: StoreDispatch) {}
 }
 
 extension AnyNodeDescription where Self: NodeDescription {

--- a/Katana/Core/NodeDescription/NodeDescription.swift
+++ b/Katana/Core/NodeDescription/NodeDescription.swift
@@ -234,6 +234,15 @@ public protocol NodeDescription: AnyNodeDescription {
                                        currentState: StateType,
                                        nextState: StateType)
   
+  
+  /**
+   This method is invoked just after the backing node is rendered in the view's hierarchy.
+   Note that `childrenDescriptions` and `applyPropsToNativeView` will be invoked before this method
+   
+   - parameter props:     the initial props with which the description is created
+   - parameter dispastch: the store dispatch function
+  */
+  static func didMount(props: PropsType, dispatch: StoreDispatch)
 }
 
 public extension NodeDescription {
@@ -261,6 +270,10 @@ public extension NodeDescription {
                                        currentState: StateType,
                                        nextState: StateType) {
     // do nothing, which means no animations
+  }
+  
+  public static func didMount(props: PropsType, dispatch: StoreDispatch) {
+    // nothing
   }
 }
 

--- a/Katana/Core/NodeDescription/NodeDescription.swift
+++ b/Katana/Core/NodeDescription/NodeDescription.swift
@@ -240,7 +240,7 @@ public protocol NodeDescription: AnyNodeDescription {
    Note that `childrenDescriptions` and `applyPropsToNativeView` will be invoked before this method
    
    - parameter props:     the initial props with which the description is created
-   - parameter dispastch: the store dispatch function
+   - parameter dispatch:  the store dispatch function. This closure is intentionally non escaping
   */
   static func didMount(props: PropsType, dispatch: StoreDispatch)
   
@@ -248,7 +248,7 @@ public protocol NodeDescription: AnyNodeDescription {
    This method is invoked just after the backing node is removed from the view's hierarchy.
    
    - parameter props:     the final props of the description
-   - parameter dispastch: the store dispatch function
+   - parameter dispastch: the store dispatch function. This closure is intentionally non escaping
    */
   static func didUnmount(props: PropsType, dispatch: StoreDispatch)
   
@@ -261,8 +261,9 @@ public protocol NodeDescription: AnyNodeDescription {
    - parameter state:           the current state of the description
    - parameter currentProps:    the current props of the description
    - parameter nextProps:       the just received props. They will be used as "props" in the next update cycle
-   - parameter dispatch:        the store dispatch function
-   - parameter update:          the update function. It can be used to update the state without triggering new update cycles
+   - parameter dispatch:        the store dispatch function. This closure is intentionally non escaping
+   - parameter update:          the update function. It can be used to update the state without triggering new update cycles.
+                                This closure is intentionally non escaping
   */
   static func descriptionWillReceiveProps(state: StateType,
                                           currentProps: PropsType,

--- a/Katana/Core/NodeDescription/NodeDescription.swift
+++ b/Katana/Core/NodeDescription/NodeDescription.swift
@@ -251,6 +251,24 @@ public protocol NodeDescription: AnyNodeDescription {
    - parameter dispastch: the store dispatch function
    */
   static func didUnmount(props: PropsType, dispatch: StoreDispatch)
+  
+
+  /**
+   This method is invoked when new props (that trigger a new update cycle) are received.
+   You have the chance to update the internal state of the description without triggering a new render
+   (new state will be immediately available in the next update cycle).
+ 
+   - parameter state:           the current state of the description
+   - parameter currentProps:    the current props of the description
+   - parameter nextProps:       the just received props. They will be used as "props" in the next update cycle
+   - parameter dispatch:        the store dispatch function
+   - parameter update:          the update function. It can be used to update the state without triggering new update cycles
+  */
+  static func descriptionWillReceiveProps(state: StateType,
+                                          currentProps: PropsType,
+                                          nextProps: PropsType,
+                                          dispatch: StoreDispatch,
+                                          update: (StateType) -> ())
 }
 
 public extension NodeDescription {
@@ -285,6 +303,13 @@ public extension NodeDescription {
   
   /// The default implementation does nothing
   public static func didUnmount(props: PropsType, dispatch: StoreDispatch) {}
+  
+  /// The default implementation does nothing
+  static func descriptionWillReceiveProps(state: StateType,
+                                          currentProps: PropsType,
+                                          nextProps: PropsType,
+                                          dispatch: StoreDispatch,
+                                          update: (StateType) -> ()){}
 }
 
 extension AnyNodeDescription where Self: NodeDescription {

--- a/KatanaTests/Core/NodeDescriptionLifecycleTests.swift
+++ b/KatanaTests/Core/NodeDescriptionLifecycleTests.swift
@@ -1,0 +1,58 @@
+//
+//  NodeDescriptionLifecycleTests.swift
+//  Katana
+//
+//  Created by Mauro Bolis on 23/12/2016.
+//  Copyright © 2016 Bending Spoons. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Katana
+
+fileprivate struct TestStructProps: NodeDescriptionProps {
+  fileprivate var alpha: CGFloat = 1.0
+  fileprivate var key: String?
+  fileprivate var frame: CGRect = .zero
+  fileprivate var testVariable: Int
+  
+  fileprivate init(testVariable: Int) {
+    self.testVariable = testVariable
+  }
+}
+
+fileprivate struct TestStruct: NodeDescription {
+  static var didMountInvoked: ((TestStructProps) -> ())? = nil
+  
+  fileprivate var props: TestStructProps
+  
+  fileprivate static func childrenDescriptions(props: TestStructProps,
+                                               state: EmptyState,
+                                               update: @escaping (EmptyState) -> (),
+                                               dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
+    return []
+  }
+  
+  fileprivate static func didMount(props: TestStructProps, dispatch: StoreDispatch) {
+    TestStruct.didMountInvoked?(props)
+  }
+}
+
+class NodeDescriptionLifecycleTests: XCTestCase {
+  func testNodeDidMount() {
+   
+    var invokedProps: TestStructProps?
+    var invoked: Bool = false
+    
+    TestStruct.didMountInvoked = {
+      invokedProps = $0
+      invoked = true
+    }
+    
+    let renderer = Renderer(rootDescription: TestStruct(props: TestStructProps(testVariable: 100)), store: nil)
+    renderer.render(in: TestView())
+    
+    XCTAssertTrue(invoked)
+    XCTAssertEqual(invokedProps?.testVariable, 100)
+  }
+}

--- a/KatanaTests/Core/NodeDescriptionLifecycleTests.swift
+++ b/KatanaTests/Core/NodeDescriptionLifecycleTests.swift
@@ -28,7 +28,7 @@ fileprivate struct InnerStruct: NodeDescription {
     InnerStruct.didMountInvoked?()
   }
   
-  fileprivate static func didUnMount(props: EmptyProps, dispatch: StoreDispatch) {
+  fileprivate static func didUnmount(props: EmptyProps, dispatch: StoreDispatch) {
     InnerStruct.didUnmountInvoked?()
   }
 }
@@ -106,5 +106,40 @@ class NodeDescriptionLifecycleTests: XCTestCase {
     XCTAssertTrue(testStructInvoked)
     XCTAssertTrue(innerStructInvoked)
     XCTAssertEqual(testStructInvokedProps?.testVariable, 101)
+  }
+  
+  
+  func testDidUnMount() {
+    var testStructInvokedProps: TestStructProps?
+    var testStructMountInvoked: Bool = false
+    var innerStructMountInvoked: Bool = false
+    var innerStructUnmountInvoked: Bool = false
+    
+    TestStruct.didMountInvoked = {
+      testStructInvokedProps = $0
+      testStructMountInvoked = true
+    }
+    
+    InnerStruct.didMountInvoked = {
+      innerStructMountInvoked = true
+    }
+    
+    InnerStruct.didUnmountInvoked = {
+      innerStructUnmountInvoked = true
+    }
+    
+    let renderer = Renderer(rootDescription: TestStruct(props: TestStructProps(testVariable: 200)), store: nil)
+    renderer.render(in: TestView())
+    
+    XCTAssertTrue(testStructMountInvoked)
+    XCTAssertTrue(innerStructMountInvoked)
+    XCTAssertFalse(innerStructUnmountInvoked)
+    XCTAssertEqual(testStructInvokedProps?.testVariable, 200)
+    
+    renderer.rootNode.update(with: TestStruct(props: TestStructProps(testVariable: 50)))
+    XCTAssertTrue(testStructMountInvoked)
+    XCTAssertTrue(innerStructMountInvoked)
+    XCTAssertTrue(innerStructUnmountInvoked)
+    XCTAssertEqual(testStructInvokedProps?.testVariable, 200) // this should not be invoked again
   }
 }


### PR DESCRIPTION
**Why**
Add new hooks. We should be able to remove non UI code from `childrenDescriptions` and in general implement more (or easily) powerful components

Fixes #89

**Changes**
Add the following methods to `NodeDescription`
```swift
static func didMount(props: PropsType, dispatch: StoreDispatch)
static func didUnmount(props: PropsType, dispatch: StoreDispatch)

static func descriptionWillReceiveProps(
  state: StateType,
  currentProps: PropsType,
  nextProps: PropsType,
  dispatch: StoreDispatch,
  update: (StateType) -> ()
)
```

**Tasks**
* [X] Add relevant tests, if needed
* [X] Add documentation, if needed
* [X] Update README, if needed
* [X] Ensure that all the examples (as well as the demo) work properly