### PR TITLE
Random Int generation fix

### DIFF
--- a/Katana/Extensions/Int+Katana.swift
+++ b/Katana/Extensions/Int+Katana.swift
@@ -13,6 +13,7 @@ import Foundation
 extension Int {
   /// A random `Int` value
   static var random: Int {
-    return Int(arc4random_uniform(UInt32.max))
+    let maxRandom = MemoryLayout<Int>.size == MemoryLayout<Int32>.size ? UInt32(Int32.max) : UInt32.max
+    return Int(arc4random_uniform(maxRandom))
   }
 }

--- a/Katana/Store/SyncAction.swift
+++ b/Katana/Store/SyncAction.swift
@@ -27,7 +27,7 @@ import Foundation
  }
  
  extension AppSyncAction {
-  func updateState(currentState: State) -> State {
+  func updatedState(currentState: State) -> State {
     guard var state = currentState as? AppState else {
       fatalError("Something went wrong")
     }


### PR DESCRIPTION
**Why**
This should prevent crashes on 32-bit platforms (e.g. iPhone 5) when generating random Int through the _Int+Katana_ extension. The problem arises when trying to initialise an Int from the result of _arc4random_uniform_ as UInt32.max > Int32.max.

**Changes**
<ul>
<li>The appropriate maximum random UInt that should be generated is chosen depending on the size of Int.</li>
</ul>