### PR TITLE
Feature/refactor middleware

### DIFF
--- a/Examples/CodingLove/CodingLove/AppDelegate.swift
+++ b/Examples/CodingLove/CodingLove/AppDelegate.swift
@@ -26,7 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let view = (self.window?.rootViewController?.view)!
         let rootBounds = UIScreen.main.bounds
         
-        let store = Store<CodingLoveState>(middlewares: [], dependencies: PostsProvider.self)
+        let store = Store<CodingLoveState>(middleware: [], dependencies: PostsProvider.self)
         
         self.renderer = Renderer(rootDescription: CodingLove(props: CodingLove.Props.build({
             $0.frame = rootBounds

--- a/Katana/Store/Store.swift
+++ b/Katana/Store/Store.swift
@@ -59,7 +59,7 @@ open class Store<StateType: State> {
   fileprivate var listeners: [StoreListener]
   
   /// The array of
-  fileprivate let middleware: [StoreMiddleware<StateType>]
+  fileprivate let middleware: [StoreMiddleware]
   
   /**
    The dependencies used in the actions side effects
@@ -109,7 +109,7 @@ open class Store<StateType: State> {
    - parameter dependencies:  the dependencies to use in the actions side effects
    - returns: An instance of store configured with the given properties
   */
-  public init(middleware: [StoreMiddleware<StateType>], dependencies: SideEffectDependencyContainer.Type) {
+  public init(middleware: [StoreMiddleware], dependencies: SideEffectDependencyContainer.Type) {
     self.listeners = []
     self.state = StateType.init()
     self.middleware = middleware

--- a/Katana/Store/Store.swift
+++ b/Katana/Store/Store.swift
@@ -38,7 +38,7 @@ public protocol AnyStore: class {
  Store's state. The only way to update the state is to dispatch an `Action`. At this point
  the store will execute the following operations:
  
- - it executes the middlewares
+ - it executes the middleware
  - it executes the side effect of the action, if implemented (see `ActionWithSideEffect`)
  - it creates the new state, by invoking the `updateState` function of the action
  - it updates the state
@@ -59,7 +59,7 @@ open class Store<StateType: State> {
   fileprivate var listeners: [StoreListener]
   
   /// The array of
-  fileprivate let middlewares: [StoreMiddleware<StateType>]
+  fileprivate let middleware: [StoreMiddleware<StateType>]
   
   /**
    The dependencies used in the actions side effects
@@ -76,7 +76,7 @@ open class Store<StateType: State> {
       return self.state
     }
     
-    var m = self.middlewares.map { middleware in
+    var m = self.middleware.map { middleware in
       middleware(getState, self.dispatch)
     }
     
@@ -93,26 +93,26 @@ open class Store<StateType: State> {
   }()
   
   /**
-   A convenience init method. The store won't have middlewares nor dependencies for the actions
+   A convenience init method. The store won't have middleware nor dependencies for the actions
    side effects
    
    - returns: An instance of store
   */
   convenience public init() {
-    self.init(middlewares: [], dependencies: EmptySideEffectDependencyContainer.self)
+    self.init(middleware: [], dependencies: EmptySideEffectDependencyContainer.self)
   }
   
   /**
    The default init method for the Store.
    
-   - parameter middlewares:   the middlewares to trigger when an action is dispatched
+   - parameter middleware:   the middleware to trigger when an action is dispatched
    - parameter dependencies:  the dependencies to use in the actions side effects
    - returns: An instance of store configured with the given properties
   */
-  public init(middlewares: [StoreMiddleware<StateType>], dependencies: SideEffectDependencyContainer.Type) {
+  public init(middleware: [StoreMiddleware<StateType>], dependencies: SideEffectDependencyContainer.Type) {
     self.listeners = []
     self.state = StateType.init()
-    self.middlewares = middlewares
+    self.middleware = middleware
     self.dependencies = dependencies
   }
 
@@ -145,28 +145,28 @@ open class Store<StateType: State> {
 }
 
 fileprivate extension Store {
-  /// Type used internally to store partially applied middlewares
+  /// Type used internally to store partially applied middleware
   fileprivate typealias PartiallyAppliedMiddleware = (_ next: @escaping StoreDispatch) -> (_ action: AnyAction) -> ()
 
   /**
-   This function composes the middlewares with the store dispatch
+   This function composes the middleware with the store dispatch
    
-   - parameter middlewares:   the middlewares to use
+   - parameter middleware:   the middleware to use
    - parameter storeDispatch: the store dispatch function
-   - returns: a function that invokes all the middlewares and then the store dispatch function
+   - returns: a function that invokes all the middleware and then the store dispatch function
   */
-  fileprivate func composeMiddlewares(_ middlewares: [PartiallyAppliedMiddleware],
+  fileprivate func composeMiddlewares(_ middleware: [PartiallyAppliedMiddleware],
                            with storeDispatch: @escaping StoreDispatch) -> StoreDispatch {
 
-    guard middlewares.count > 0 else {
+    guard middleware.count > 0 else {
       return storeDispatch
     }
   
-    guard middlewares.count > 1 else {
-      return middlewares.first!(storeDispatch)
+    guard middleware.count > 1 else {
+      return middleware.first!(storeDispatch)
     }
   
-    var m = middlewares
+    var m = middleware
     let last = m.removeLast()
   
     return m.reduce(last(storeDispatch), { chain, middleware in

--- a/Katana/Store/StoreTypealiases.swift
+++ b/Katana/Store/StoreTypealiases.swift
@@ -14,7 +14,7 @@ public typealias StoreListener = () -> ()
 /// Typealias for the `Store` listener unsubscribe closure
 public typealias StoreUnsubscribe = () -> ()
 
-/// Typealias for the `Store` middlewares
+/// Typealias for the `Store` middleware
 public typealias StoreMiddleware<StateType: State> =
   (_ getState: @escaping () -> StateType, _ dispatch: @escaping StoreDispatch) ->
     (_ next: @escaping StoreDispatch) ->

--- a/Katana/Store/StoreTypealiases.swift
+++ b/Katana/Store/StoreTypealiases.swift
@@ -15,8 +15,8 @@ public typealias StoreListener = () -> ()
 public typealias StoreUnsubscribe = () -> ()
 
 /// Typealias for the `Store` middleware
-public typealias StoreMiddleware<StateType: State> =
-  (_ getState: @escaping () -> StateType, _ dispatch: @escaping StoreDispatch) ->
+public typealias StoreMiddleware =
+  (_ getState: @escaping () -> State, _ dispatch: @escaping StoreDispatch) ->
     (_ next: @escaping StoreDispatch) ->
       (_ action: AnyAction) -> ()
 

--- a/KatanaTests/Storage/Core/MiddlewareTests.swift
+++ b/KatanaTests/Storage/Core/MiddlewareTests.swift
@@ -17,7 +17,7 @@ class MiddlewareTests: XCTestCase {
     var storeBefore: Any?
     var storeAfter: Any?
     
-    let expectation = self.expectation(description: "Middlewares")
+    let expectation = self.expectation(description: "Middleware")
     
     let middleware: StoreMiddleware<AppState> = { getState, dispatch in
       return { next in
@@ -31,7 +31,7 @@ class MiddlewareTests: XCTestCase {
       }
     }
     
-    let store = Store<AppState>(middlewares: [middleware], dependencies: EmptySideEffectDependencyContainer.self)
+    let store = Store<AppState>(middleware: [middleware], dependencies: EmptySideEffectDependencyContainer.self)
     let initialState = store.state
     let action = AddTodoAction(title: "New Todo")
     store.dispatch(action)
@@ -49,7 +49,7 @@ class MiddlewareTests: XCTestCase {
   func testMiddlewareCanBlockPropagation() {
     var invokationOrder: [String] = []
     
-    let expectation = self.expectation(description: "Middlewares")
+    let expectation = self.expectation(description: "Middleware")
     
     let basicMiddleware: StoreMiddleware<AppState> = { getState, dispatch in
       return { next in
@@ -70,7 +70,7 @@ class MiddlewareTests: XCTestCase {
     }
     
     let store = Store<AppState>(
-      middlewares: [basicMiddleware, secondMiddleware],
+      middleware: [basicMiddleware, secondMiddleware],
       dependencies: EmptySideEffectDependencyContainer.self
     )
     
@@ -92,7 +92,7 @@ class MiddlewareTests: XCTestCase {
     var storeAfter: Any?
     var invokationOrder: [String] = []
     
-    let expectation = self.expectation(description: "Middlewares")
+    let expectation = self.expectation(description: "Middleware")
     
     let basicMiddleware: StoreMiddleware<AppState> = { getState, dispatch in
       return { next in
@@ -117,7 +117,7 @@ class MiddlewareTests: XCTestCase {
     }
     
     let store = Store<AppState>(
-      middlewares: [basicMiddleware, secondMiddleware],
+      middleware: [basicMiddleware, secondMiddleware],
       dependencies: EmptySideEffectDependencyContainer.self
     )
     
@@ -139,7 +139,7 @@ class MiddlewareTests: XCTestCase {
   func testGenericMiddleware() {
     var invokationOrder: [String] = []
     
-    let expectation = self.expectation(description: "Middlewares")
+    let expectation = self.expectation(description: "Middleware")
     
     let basicMiddleware: StoreMiddleware<AppState> = { getState, dispatch in
       return { next in
@@ -161,7 +161,7 @@ class MiddlewareTests: XCTestCase {
     }
     
     let store = Store<AppState>(
-      middlewares: [basicMiddleware, secondMiddleware],
+      middleware: [basicMiddleware, secondMiddleware],
       dependencies: EmptySideEffectDependencyContainer.self
     )
     

--- a/KatanaTests/Storage/Core/MiddlewareTests.swift
+++ b/KatanaTests/Storage/Core/MiddlewareTests.swift
@@ -19,7 +19,7 @@ class MiddlewareTests: XCTestCase {
     
     let expectation = self.expectation(description: "Middleware")
     
-    let middleware: StoreMiddleware<AppState> = { getState, dispatch in
+    let middleware: StoreMiddleware = { getState, dispatch in
       return { next in
         return { action in
           dispatchedAction = action
@@ -51,7 +51,7 @@ class MiddlewareTests: XCTestCase {
     
     let expectation = self.expectation(description: "Middleware")
     
-    let basicMiddleware: StoreMiddleware<AppState> = { getState, dispatch in
+    let basicMiddleware: StoreMiddleware = { getState, dispatch in
       return { next in
         return { action in
           invokationOrder.append("basic")
@@ -60,7 +60,7 @@ class MiddlewareTests: XCTestCase {
       }
     }
     
-    let secondMiddleware: StoreMiddleware<State> = { getState, dispatch in
+    let secondMiddleware: StoreMiddleware = { getState, dispatch in
       return { next in
         return { action in
           invokationOrder.append("second")
@@ -94,7 +94,7 @@ class MiddlewareTests: XCTestCase {
     
     let expectation = self.expectation(description: "Middleware")
     
-    let basicMiddleware: StoreMiddleware<AppState> = { getState, dispatch in
+    let basicMiddleware: StoreMiddleware = { getState, dispatch in
       return { next in
         return { action in
           invokationOrder.append("basic")
@@ -106,7 +106,7 @@ class MiddlewareTests: XCTestCase {
       }
     }
     
-    let secondMiddleware: StoreMiddleware<AppState> = { getState, dispatch in
+    let secondMiddleware: StoreMiddleware = { getState, dispatch in
       return { next in
         return { action in
           invokationOrder.append("second")
@@ -141,7 +141,7 @@ class MiddlewareTests: XCTestCase {
     
     let expectation = self.expectation(description: "Middleware")
     
-    let basicMiddleware: StoreMiddleware<AppState> = { getState, dispatch in
+    let basicMiddleware: StoreMiddleware = { getState, dispatch in
       return { next in
         return { action in
           invokationOrder.append("basic")
@@ -150,7 +150,7 @@ class MiddlewareTests: XCTestCase {
       }
     }
     
-    let secondMiddleware: StoreMiddleware<State> = { getState, dispatch in
+    let secondMiddleware: StoreMiddleware = { getState, dispatch in
       return { next in
         return { action in
           invokationOrder.append("second")

--- a/KatanaTests/Storage/Core/SideEffectTests.swift
+++ b/KatanaTests/Storage/Core/SideEffectTests.swift
@@ -46,7 +46,7 @@ class SideEffectTests: XCTestCase {
     }, updatedInvokedClosure: nil)
 
     
-    let store = Store<AppState>(middlewares: [], dependencies: EmptySideEffectDependencyContainer.self)
+    let store = Store<AppState>(middleware: [], dependencies: EmptySideEffectDependencyContainer.self)
     let initialState = store.state
     store.dispatch(action)
     
@@ -69,7 +69,7 @@ class SideEffectTests: XCTestCase {
 
     }, updatedInvokedClosure: nil)
     
-    let store = Store<AppState>(middlewares: [], dependencies: SimpleDependencyContainer.self)
+    let store = Store<AppState>(middleware: [], dependencies: SimpleDependencyContainer.self)
     let initialState = store.state
     store.dispatch(action)
     
@@ -104,7 +104,7 @@ class SideEffectTests: XCTestCase {
       action1expectation.fulfill()
     }
     
-    let store = Store<AppState>(middlewares: [], dependencies: SimpleDependencyContainer.self)
+    let store = Store<AppState>(middleware: [], dependencies: SimpleDependencyContainer.self)
     store.dispatch(action1)
     
     self.waitForExpectations(timeout: 10) { (error) in

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ renderer!.render(in: view)
 
 
 - [x] sync/async/sideEffect actions
-- [x] middlewares
+- [x] middleware
 - [x] automatic UI update
 - [x] native redux-like implementation
 - [x] native react-like implementation


### PR DESCRIPTION
**Why**
Fix #86 and #87 

**Changes**
Middleware are not anymore generic.
People can now write reusable (library) middleware and can leverage protocol adoption to work with the state

**Tasks**
* [x] Add relevant tests, if needed
* [x] Add documentation, if needed
* [X] Update README, if needed
* [X] Ensure that all the examples (as well as the demo) work properly