### PR TITLE
Improve lifecycle api

### DIFF
--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -395,18 +395,33 @@ extension Node {
       return
     }
 
-    // invoke the proper lifecycle hook
     var newState = state
-
-    let update: (Description.StateType) -> () = { newState = $0 }
-
-    Description.descriptionWillReceiveProps(
-      state: state,
-      currentProps: self.description.props,
-      nextProps: description.props,
-      dispatch: self.storeDispatch,
-      update: update
-    )
+    
+    // invoke the proper lifecycle hook if props changes
+    if self.description.props != description.props {
+      
+      var syncStateUpdate = true
+      
+      let update: (Description.StateType) -> () = {
+        if syncStateUpdate {
+          newState = $0
+          
+        } else {
+          self.update(for: $0)
+        }
+      }
+      
+      Description.descriptionWillReceiveProps(
+        state: state,
+        currentProps: self.description.props,
+        nextProps: description.props,
+        dispatch: self.storeDispatch,
+        update: update
+      )
+      
+      // too late, from now on an update will trigger a new update cycle
+      syncStateUpdate = false
+    }
 
     // update the internal state
     let currentState = self.state

--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -193,7 +193,7 @@ extension Node {
                                          node: self)
     }
 
-    Description.didMount(props: self.description.props, dispatch: self.storeDispatch)
+    Description.didMount(props: self.description.props, dispatch: self.storeDispatch, update: update)
 
     children.forEach { child in
       let child = child as! InternalAnyNode
@@ -402,12 +402,14 @@ extension Node {
       
       var syncStateUpdate = true
       
-      let update: (Description.StateType) -> () = {
+      let update = { [weak self] (state: Description.StateType) in
         if syncStateUpdate {
-          newState = $0
+          newState = state
           
         } else {
-          self.update(for: $0)
+          DispatchQueue.main.async {
+            self?.update(for: state)
+          }
         }
       }
       

--- a/Katana/Core/NodeDescription/NodeDescription.swift
+++ b/Katana/Core/NodeDescription/NodeDescription.swift
@@ -238,8 +238,9 @@ public protocol NodeDescription: AnyNodeDescription {
    
    - parameter props:     the initial props with which the description is created
    - parameter dispatch:  the store dispatch function
+   - parameter update:    the update function. It will trigger a new render cycle
   */
-  static func didMount(props: PropsType, dispatch: @escaping StoreDispatch)
+  static func didMount(props: PropsType, dispatch: @escaping StoreDispatch, update: @escaping (StateType) -> ())
 
   /**
    This method is invoked just after the backing node is removed from the view's hierarchy.
@@ -295,7 +296,7 @@ public extension NodeDescription {
   }
 
   /// The default implementation does nothing
-  public static func didMount(props: PropsType, dispatch: @escaping StoreDispatch) {}
+  public static func didMount(props: PropsType, dispatch: @escaping StoreDispatch, update: @escaping (StateType) -> ()) {}
 
   /// The default implementation does nothing
   public static func didUnmount(props: PropsType, dispatch: @escaping StoreDispatch) {}

--- a/Katana/Core/NodeDescription/NodeDescription.swift
+++ b/Katana/Core/NodeDescription/NodeDescription.swift
@@ -237,35 +237,34 @@ public protocol NodeDescription: AnyNodeDescription {
    Note that `childrenDescriptions` and `applyPropsToNativeView` will be invoked before this method
    
    - parameter props:     the initial props with which the description is created
-   - parameter dispatch:  the store dispatch function. This closure is intentionally non escaping
+   - parameter dispatch:  the store dispatch function
   */
-  static func didMount(props: PropsType, dispatch: StoreDispatch)
+  static func didMount(props: PropsType, dispatch: @escaping StoreDispatch)
 
   /**
    This method is invoked just after the backing node is removed from the view's hierarchy.
    
    - parameter props:     the final props of the description
-   - parameter dispastch: the store dispatch function. This closure is intentionally non escaping
+   - parameter dispastch: the store dispatch function
    */
-  static func didUnmount(props: PropsType, dispatch: StoreDispatch)
+  static func didUnmount(props: PropsType, dispatch: @escaping StoreDispatch)
 
   /**
    This method is invoked when new props (that trigger a new update cycle) are received.
    You have the chance to update the internal state of the description without triggering a new render
-   (new state will be immediately available in the next update cycle).
+   (new state will be immediately available in the next update cycle) if `update` is invoked synchronously.
  
    - parameter state:           the current state of the description
    - parameter currentProps:    the current props of the description
    - parameter nextProps:       the just received props. They will be used as "props" in the next update cycle
-   - parameter dispatch:        the store dispatch function. This closure is intentionally non escaping
+   - parameter dispatch:        the store dispatch function
    - parameter update:          the update function. It can be used to update the state without triggering new update cycles.
-                                This closure is intentionally non escaping
   */
   static func descriptionWillReceiveProps(state: StateType,
                                           currentProps: PropsType,
                                           nextProps: PropsType,
-                                          dispatch: StoreDispatch,
-                                          update: (StateType) -> ())
+                                          dispatch: @escaping StoreDispatch,
+                                          update: @escaping (StateType) -> ())
 }
 
 public extension NodeDescription {
@@ -296,17 +295,17 @@ public extension NodeDescription {
   }
 
   /// The default implementation does nothing
-  public static func didMount(props: PropsType, dispatch: StoreDispatch) {}
+  public static func didMount(props: PropsType, dispatch: @escaping StoreDispatch) {}
 
   /// The default implementation does nothing
-  public static func didUnmount(props: PropsType, dispatch: StoreDispatch) {}
+  public static func didUnmount(props: PropsType, dispatch: @escaping StoreDispatch) {}
 
   /// The default implementation does nothing
   static func descriptionWillReceiveProps(state: StateType,
                                           currentProps: PropsType,
                                           nextProps: PropsType,
-                                          dispatch: StoreDispatch,
-                                          update: (StateType) -> ()) {}
+                                          dispatch: @escaping StoreDispatch,
+                                          update: @escaping (StateType) -> ()) {}
 }
 
 extension AnyNodeDescription where Self: NodeDescription {

--- a/KatanaTests/Core/NodeDescriptionLifecycleTests.swift
+++ b/KatanaTests/Core/NodeDescriptionLifecycleTests.swift
@@ -23,7 +23,9 @@ fileprivate struct InnerStruct: NodeDescription {
     return []
   }
 
-  fileprivate static func didMount(props: EmptyProps, dispatch: @escaping StoreDispatch) {
+  fileprivate static func didMount(props: EmptyProps,
+                                   dispatch: @escaping StoreDispatch,
+                                   update: @escaping (EmptyState) -> ()) {
     InnerStruct.didMountInvoked?()
   }
 
@@ -80,7 +82,10 @@ fileprivate struct TestStruct: NodeDescription {
     }
   }
 
-  fileprivate static func didMount(props: TestStructProps, dispatch: @escaping StoreDispatch) {
+  fileprivate static func didMount(props: TestStructProps,
+                                   dispatch: @escaping StoreDispatch,
+                                   update: @escaping (TestStructState) -> ()) {
+
     TestStruct.didMountInvoked?(props)
   }
 
@@ -239,8 +244,12 @@ class NodeDescriptionLifecycleTests: XCTestCase {
     XCTAssertEqual(TestStruct.states, [0, 50]) // also checks that the childrenDescriptions is invoked the proper number of times
     
     self.waitForExpectations(timeout: 10, handler: { err in
-      XCTAssertNil(err)
-      XCTAssertEqual(TestStruct.states, [0, 50, 999])
+      // we need to wait a little bit before the render.. we should find a better way
+      DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        XCTAssertNotNil(renderer) // we need to keep renderer alive
+        XCTAssertNil(err)
+        XCTAssertEqual(TestStruct.states, [0, 50, 999])
+      }
     })
   }
 }

--- a/KatanaTests/Core/NodeDescriptionLifecycleTests.swift
+++ b/KatanaTests/Core/NodeDescriptionLifecycleTests.swift
@@ -23,11 +23,11 @@ fileprivate struct InnerStruct: NodeDescription {
     return []
   }
 
-  fileprivate static func didMount(props: EmptyProps, dispatch: StoreDispatch) {
+  fileprivate static func didMount(props: EmptyProps, dispatch: @escaping StoreDispatch) {
     InnerStruct.didMountInvoked?()
   }
 
-  fileprivate static func didUnmount(props: EmptyProps, dispatch: StoreDispatch) {
+  fileprivate static func didUnmount(props: EmptyProps, dispatch: @escaping StoreDispatch) {
     InnerStruct.didUnmountInvoked?()
   }
 }
@@ -59,6 +59,8 @@ fileprivate struct TestStruct: NodeDescription {
   static var didMountInvoked: ((TestStructProps) -> ())? = nil
   static var willReceivePropsInvoked: ((TestStructProps, TestStructProps) -> ())? = nil
   static var states: [Int] = []
+  static var useAsyncUpdate: Bool = false
+  static var asyncUpdateCallback: (() -> ())?
 
   fileprivate var props: TestStructProps
 
@@ -78,18 +80,28 @@ fileprivate struct TestStruct: NodeDescription {
     }
   }
 
-  fileprivate static func didMount(props: TestStructProps, dispatch: StoreDispatch) {
+  fileprivate static func didMount(props: TestStructProps, dispatch: @escaping StoreDispatch) {
     TestStruct.didMountInvoked?(props)
   }
 
   fileprivate static func descriptionWillReceiveProps(state: TestStructState,
                                                       currentProps: TestStructProps,
                                                       nextProps: TestStructProps,
-                                                      dispatch: StoreDispatch,
-                                                      update: (TestStructState) -> ()) {
+                                                      dispatch: @escaping StoreDispatch,
+                                                      update: @escaping (TestStructState) -> ()) {
 
-    update(TestStructState(state: nextProps.testVariable))
+    if state.state != 999 {
+      update(TestStructState(state: nextProps.testVariable))
+    }
+    
     TestStruct.willReceivePropsInvoked?(currentProps, nextProps)
+    
+    if TestStruct.useAsyncUpdate {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
+        update(TestStructState(state: 999))
+        TestStruct.asyncUpdateCallback?()
+      })
+    }
   }
 }
 
@@ -192,5 +204,43 @@ class NodeDescriptionLifecycleTests: XCTestCase {
     XCTAssertEqual(willReceiveCurrentProps?.testVariable, 200)
     XCTAssertEqual(willReceiveNextProps?.testVariable, 50)
     XCTAssertEqual(TestStruct.states, [0, 50]) // also checks that the childrenDescriptions is invoked the proper number of times
+  }
+  
+  func testWillReceivePropsAsyncUpdate() {
+    var willReceiveCurrentProps: TestStructProps?
+    var willReceiveNextProps: TestStructProps?
+    var willReceiveInvoked: Bool = false
+    let expecation = self.expectation(description: "Render")
+    
+    TestStruct.states = []
+    TestStruct.useAsyncUpdate = true
+    
+    TestStruct.asyncUpdateCallback = {
+      expecation.fulfill()
+    }
+    
+    TestStruct.willReceivePropsInvoked = { curr, next in
+      willReceiveInvoked = true
+      willReceiveCurrentProps = curr
+      willReceiveNextProps = next
+    }
+    
+    let renderer = Renderer(rootDescription: TestStruct(props: TestStructProps(testVariable: 200)), store: nil)
+    renderer.render(in: TestView())
+    
+    XCTAssertFalse(willReceiveInvoked)
+    XCTAssertEqual(TestStruct.states, [0])
+    
+    renderer.rootNode.update(with: TestStruct(props: TestStructProps(testVariable: 50)))
+    
+    XCTAssertTrue(willReceiveInvoked)
+    XCTAssertEqual(willReceiveCurrentProps?.testVariable, 200)
+    XCTAssertEqual(willReceiveNextProps?.testVariable, 50)
+    XCTAssertEqual(TestStruct.states, [0, 50]) // also checks that the childrenDescriptions is invoked the proper number of times
+    
+    self.waitForExpectations(timeout: 10, handler: { err in
+      XCTAssertNil(err)
+      XCTAssertEqual(TestStruct.states, [0, 50, 999])
+    })
   }
 }


### PR DESCRIPTION
**Why**
- Fix `willReceive` triggered also when the state is changed
- Add possibility to invoke update and dispatch asynchronously
- didMount now has `update`

**Changes**
Dispatch and Update are escaping

**Tasks**
* [X] Add relevant tests, if needed
* [X] Add documentation, if needed
* [X] Update README, if needed
* [X] Ensure that all the examples (as well as the demo) work properly