### PR TITLE
Make PlasticView scaleValue public

### DIFF
--- a/Katana/Plastic/PlasticView.swift
+++ b/Katana/Plastic/PlasticView.swift
@@ -109,7 +109,7 @@ public class PlasticView {
    - parameter value: the value to scale
    - returns: the scaled value
   */
-  func scaleValue(_ value: Value) -> CGFloat {
+  public func scaleValue(_ value: Value) -> CGFloat {
     return value.scale(by: multiplier)
   }
 


### PR DESCRIPTION
**Why**
Accessing the scaleValue method of PlasticView is sometimes useful in advanced layout scenarios.

**Changes**
PlasticView scaleValue method is now public

**Tasks**
* [x] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [x] Ensure that all the examples (as well as the demo) work properly