### PR TITLE
Release 0.5.0

### DIFF
--- a/Katana.xcodeproj/project.pbxproj
+++ b/Katana.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5115A6F41E26A425007EA0FB /* LinkeableAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5115A6F31E26A425007EA0FB /* LinkeableAction.swift */; };
+		5115A6F61E26A67E007EA0FB /* ActionLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5115A6F51E26A67E007EA0FB /* ActionLinks.swift */; };
+		5115A6F81E26A6E9007EA0FB /* ActionLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5115A6F71E26A6E9007EA0FB /* ActionLinker.swift */; };
+		5115A6FC1E2777AC007EA0FB /* ActionLinkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5115A6FB1E2777AC007EA0FB /* ActionLinkerTests.swift */; };
+		5115A6FD1E277D60007EA0FB /* ActionLinkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5115A6FB1E2777AC007EA0FB /* ActionLinkerTests.swift */; };
+		5115A6FE1E27C5BD007EA0FB /* ActionLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5115A6F71E26A6E9007EA0FB /* ActionLinker.swift */; };
+		5115A6FF1E27C5DC007EA0FB /* ActionLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5115A6F51E26A67E007EA0FB /* ActionLinks.swift */; };
+		5115A7001E27C5E0007EA0FB /* LinkeableAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5115A6F31E26A425007EA0FB /* LinkeableAction.swift */; };
 		652647421DEB1CCE000483E9 /* NativeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652647411DEB1CCE000483E9 /* NativeButton.swift */; };
 		652647471DEB2DD1000483E9 /* DecrementCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652647451DEB2DD1000483E9 /* DecrementCounter.swift */; };
 		652647481DEB2DD1000483E9 /* DecrementCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652647451DEB2DD1000483E9 /* DecrementCounter.swift */; };
@@ -270,6 +278,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5115A6F31E26A425007EA0FB /* LinkeableAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkeableAction.swift; sourceTree = "<group>"; };
+		5115A6F51E26A67E007EA0FB /* ActionLinks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionLinks.swift; sourceTree = "<group>"; };
+		5115A6F71E26A6E9007EA0FB /* ActionLinker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionLinker.swift; sourceTree = "<group>"; };
+		5115A6FB1E2777AC007EA0FB /* ActionLinkerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionLinkerTests.swift; sourceTree = "<group>"; };
 		6513094F1DC3529F00007B6B /* KatanaElements.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = KatanaElements.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		652647411DEB1CCE000483E9 /* NativeButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NativeButton.swift; sourceTree = "<group>"; };
 		652647451DEB2DD1000483E9 /* DecrementCounter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DecrementCounter.swift; path = Common/Actions/DecrementCounter.swift; sourceTree = "<group>"; };
@@ -463,6 +475,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5115A7011E27D8E4007EA0FB /* Middleware */ = {
+			isa = PBXGroup;
+			children = (
+				5115A7021E27D8EE007EA0FB /* ActionLinker */,
+			);
+			path = Middleware;
+			sourceTree = "<group>";
+		};
+		5115A7021E27D8EE007EA0FB /* ActionLinker */ = {
+			isa = PBXGroup;
+			children = (
+				5115A6F31E26A425007EA0FB /* LinkeableAction.swift */,
+				5115A6F51E26A67E007EA0FB /* ActionLinks.swift */,
+				5115A6F71E26A6E9007EA0FB /* ActionLinker.swift */,
+			);
+			path = ActionLinker;
+			sourceTree = "<group>";
+		};
 		652647431DEB2D7B000483E9 /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -684,6 +714,7 @@
 		8133154A1D7B726000FBE210 /* Store */ = {
 			isa = PBXGroup;
 			children = (
+				5115A7011E27D8E4007EA0FB /* Middleware */,
 				A1CA314C1DC37DBF00982BE9 /* Action.swift */,
 				A1CA314E1DC37DBF00982BE9 /* State.swift */,
 				A1CA314F1DC37DBF00982BE9 /* Store.swift */,
@@ -810,6 +841,7 @@
 				A1CA315A1DC3A01F00982BE9 /* SyncActionTests.swift */,
 				A14EB8BF1DC3A62B00DE0BD9 /* AsyncActionTests.swift */,
 				A1576C2C1DC72E03008281C0 /* SideEffectTests.swift */,
+				5115A6FB1E2777AC007EA0FB /* ActionLinkerTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1364,6 +1396,7 @@
 				65BF2E6F1DE339C900441784 /* AnimationType.swift in Sources */,
 				65BF2E701DE339C900441784 /* ChildrenAnimations.swift in Sources */,
 				65BF2E711DE339C900441784 /* AnimationUtils.swift in Sources */,
+				5115A6FE1E27C5BD007EA0FB /* ActionLinker.swift in Sources */,
 				65BF2EA31DE363A100441784 /* NSView+Utils.swift in Sources */,
 				65BF2E721DE339C900441784 /* AnimationContainer.swift in Sources */,
 				65BF2E731DE339C900441784 /* Animation.swift in Sources */,
@@ -1380,6 +1413,7 @@
 				65BF2E7C1DE339C900441784 /* CoordinateConvertible.swift in Sources */,
 				65BF2E7D1DE339C900441784 /* PlasticNode.swift in Sources */,
 				65BF2E7E1DE339C900441784 /* PlasticNodeDescription.swift in Sources */,
+				5115A7001E27C5E0007EA0FB /* LinkeableAction.swift in Sources */,
 				65BF2E7F1DE339C900441784 /* PlasticReferenceSizeable.swift in Sources */,
 				65BF2E801DE339C900441784 /* PlasticView+Convenience.swift in Sources */,
 				65BF2E811DE339C900441784 /* PlasticView.swift in Sources */,
@@ -1395,6 +1429,7 @@
 				65BF2E8B1DE339C900441784 /* SyncAction.swift in Sources */,
 				65BF2E8C1DE339C900441784 /* AsyncAction.swift in Sources */,
 				65BF2E8D1DE339C900441784 /* ActionWithSideEffect.swift in Sources */,
+				5115A6FF1E27C5DC007EA0FB /* ActionLinks.swift in Sources */,
 				65BF2EA11DE3639600441784 /* NSView+PlatformNativeView.swift in Sources */,
 				65BF2E8E1DE339C900441784 /* SideEffectDependencyContainer.swift in Sources */,
 			);
@@ -1416,6 +1451,7 @@
 				65BF2EF51DE8301E00441784 /* Collections.swift in Sources */,
 				65BF2EF61DE8301E00441784 /* HierarchyManagers.swift in Sources */,
 				65BF2EF71DE8301E00441784 /* PlasticBasicLayoutTests.swift in Sources */,
+				5115A6FD1E277D60007EA0FB /* ActionLinkerTests.swift in Sources */,
 				65BF2EF81DE8301E00441784 /* PlasticContainerTests.swift in Sources */,
 				65BF2EF91DE8301E00441784 /* PlasticConvenienceLayoutTests.swift in Sources */,
 				65BF2EFA1DE8301E00441784 /* PlasticDimensionsTests.swift in Sources */,
@@ -1470,6 +1506,7 @@
 				8133155F1D7B726000FBE210 /* NodeDescriptionWithChildren.swift in Sources */,
 				8133155E1D7B726000FBE210 /* NodeDescription.swift in Sources */,
 				A1277CEC1DD32037007F68E5 /* AnyNode.swift in Sources */,
+				5115A6F41E26A425007EA0FB /* LinkeableAction.swift in Sources */,
 				65BF2E9D1DE3634100441784 /* UIView+PlatformNativeView.swift in Sources */,
 				8133157F1D7B726000FBE210 /* ViewsContainer.swift in Sources */,
 				8133157C1D7B726000FBE210 /* Size.swift in Sources */,
@@ -1483,6 +1520,7 @@
 				A1C9C1CD1DD36BE50067F8E0 /* Animation.swift in Sources */,
 				8133155C1D7B726000FBE210 /* Node.swift in Sources */,
 				A1CA31551DC37DBF00982BE9 /* StoreTypealiases.swift in Sources */,
+				5115A6F61E26A67E007EA0FB /* ActionLinks.swift in Sources */,
 				A1C9C1CB1DD36BD90067F8E0 /* AnimationType.swift in Sources */,
 				A1CA31591DC39E1700982BE9 /* SyncAction.swift in Sources */,
 				A15700671DD4C33700361068 /* AnimationPropsTransfomer.swift in Sources */,
@@ -1501,6 +1539,7 @@
 				8133157B1D7B726000FBE210 /* PlasticView.swift in Sources */,
 				813315781D7B726000FBE210 /* PlasticNodeDescription.swift in Sources */,
 				8133157E1D7B726000FBE210 /* ViewsContainer+Helpers.swift in Sources */,
+				5115A6F81E26A6E9007EA0FB /* ActionLinker.swift in Sources */,
 				A1CA31541DC37DBF00982BE9 /* Store.swift in Sources */,
 				8133157D1D7B726000FBE210 /* Value.swift in Sources */,
 				A1CA315D1DC3A24000982BE9 /* AsyncAction.swift in Sources */,
@@ -1512,6 +1551,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				81911DB71D7D916B00123C54 /* NodeTest.swift in Sources */,
+				5115A6FC1E2777AC007EA0FB /* ActionLinkerTests.swift in Sources */,
 				A1576C2F1DC7305F008281C0 /* DependencyContainer.swift in Sources */,
 				A14EB8C01DC3A62B00DE0BD9 /* AsyncActionTests.swift in Sources */,
 				65BF2EDB1DE745CF00441784 /* Typealiases.swift in Sources */,

--- a/Katana/Core/NodeDescription/NodeDescription.swift
+++ b/Katana/Core/NodeDescription/NodeDescription.swift
@@ -237,35 +237,35 @@ public protocol NodeDescription: AnyNodeDescription {
    Note that `childrenDescriptions` and `applyPropsToNativeView` will be invoked before this method
    
    - parameter props:     the initial props with which the description is created
-   - parameter dispatch:  the store dispatch function. This closure is intentionally non escaping
+   - parameter dispatch:  the store dispatch function
+   - parameter update:    the update function. It will trigger a new render cycle
   */
-  static func didMount(props: PropsType, dispatch: StoreDispatch)
+  static func didMount(props: PropsType, dispatch: @escaping StoreDispatch, update: @escaping (StateType) -> ())
 
   /**
    This method is invoked just after the backing node is removed from the view's hierarchy.
    
    - parameter props:     the final props of the description
-   - parameter dispastch: the store dispatch function. This closure is intentionally non escaping
+   - parameter dispastch: the store dispatch function
    */
-  static func didUnmount(props: PropsType, dispatch: StoreDispatch)
+  static func didUnmount(props: PropsType, dispatch: @escaping StoreDispatch)
 
   /**
    This method is invoked when new props (that trigger a new update cycle) are received.
    You have the chance to update the internal state of the description without triggering a new render
-   (new state will be immediately available in the next update cycle).
+   (new state will be immediately available in the next update cycle) if `update` is invoked synchronously.
  
    - parameter state:           the current state of the description
    - parameter currentProps:    the current props of the description
    - parameter nextProps:       the just received props. They will be used as "props" in the next update cycle
-   - parameter dispatch:        the store dispatch function. This closure is intentionally non escaping
+   - parameter dispatch:        the store dispatch function
    - parameter update:          the update function. It can be used to update the state without triggering new update cycles.
-                                This closure is intentionally non escaping
   */
   static func descriptionWillReceiveProps(state: StateType,
                                           currentProps: PropsType,
                                           nextProps: PropsType,
-                                          dispatch: StoreDispatch,
-                                          update: (StateType) -> ())
+                                          dispatch: @escaping StoreDispatch,
+                                          update: @escaping (StateType) -> ())
 }
 
 public extension NodeDescription {
@@ -296,17 +296,17 @@ public extension NodeDescription {
   }
 
   /// The default implementation does nothing
-  public static func didMount(props: PropsType, dispatch: StoreDispatch) {}
+  public static func didMount(props: PropsType, dispatch: @escaping StoreDispatch, update: @escaping (StateType) -> ()) {}
 
   /// The default implementation does nothing
-  public static func didUnmount(props: PropsType, dispatch: StoreDispatch) {}
+  public static func didUnmount(props: PropsType, dispatch: @escaping StoreDispatch) {}
 
   /// The default implementation does nothing
   static func descriptionWillReceiveProps(state: StateType,
                                           currentProps: PropsType,
                                           nextProps: PropsType,
-                                          dispatch: StoreDispatch,
-                                          update: (StateType) -> ()) {}
+                                          dispatch: @escaping StoreDispatch,
+                                          update: @escaping (StateType) -> ()) {}
 }
 
 extension AnyNodeDescription where Self: NodeDescription {

--- a/Katana/Plastic/PlasticView.swift
+++ b/Katana/Plastic/PlasticView.swift
@@ -109,7 +109,7 @@ public class PlasticView {
    - parameter value: the value to scale
    - returns: the scaled value
   */
-  func scaleValue(_ value: Value) -> CGFloat {
+  public func scaleValue(_ value: Value) -> CGFloat {
     return value.scale(by: multiplier)
   }
 

--- a/Katana/Store/Middleware/ActionLinker/ActionLinker.swift
+++ b/Katana/Store/Middleware/ActionLinker/ActionLinker.swift
@@ -1,0 +1,120 @@
+//
+//  ActionLinker.swift
+//  Katana
+//
+//  Created by Riccardo Cipolleschi on 11/01/2017.
+//  Copyright © 2017 Bending Spoons. All rights reserved.
+//
+
+import Foundation
+
+/**
+ The engine that dispatches all the actions that depends on a triggered source action.
+ This is invoked every time an action is dispatched. 
+ The ActionLinker is responsible to check if there are actions that must be issued after a source actionis dispatched.
+ For each of this actions, it checks if the conditions are met: if yes, they are dispatched.
+ */
+public struct ActionLinker {
+  
+  /**
+   Function that takes an array of action links and reduce them to a dictionary.
+   This is useful to get efficiently all the links of a specific source action.
+   
+   - parameter from: the array to be reduced
+   - returns: a dictionary with the name of the action and the list of linked actions
+   - warning: it does not remove duplicated actions!
+   */
+  static func reduceLinks(from array: [ActionLinks]) -> [String: [LinkeableAction.Type]] {
+    var tmpLinks: [String: [LinkeableAction.Type]] = [:]
+    
+    for tuple in array {
+      let actionType = ActionLinker.stringName(for: tuple.source)
+      tmpLinks[actionType] = tmpLinks[actionType] ?? []
+      tmpLinks[actionType] = tmpLinks[actionType]! + tuple.links
+    }
+    
+    return tmpLinks
+  }
+  
+  /**
+   Core function of the linker.
+   Extract the list of actions linked to a source that has been dispatched.
+   If any, it executes them in order. Right now the order is relevant and it is the same used in the initialization.
+   
+
+   - parameter newState: state of the application after the source action is applied
+   - parameter oldState: state of the application before the source action is applied
+   - parameter action: the source action that could trigger the action chain
+   - parameter links: the array with all the linked actions
+   - parameter dispatch: the dispatch function of the Store.
+   */
+  static func dispatchActions(for newState: State,
+                              oldState: State,
+                              sourceAction: AnyAction,
+                              links: [String: [LinkeableAction.Type]],
+                              dispatch: (Action) -> Void) {
+    
+    let linkedActions = links[ActionLinker.stringName(for: sourceAction)]
+    
+    guard let actions = linkedActions else {
+      return
+    }
+    
+    for action in actions {
+      if let source = sourceAction as? Action,
+        let action = action.init(oldState: oldState, newState: newState, sourceAction: source) {
+          dispatch(action)
+      }
+    }
+    
+  }
+
+  /**
+   This takes an AnyAction and returns the name of the action by considering its namespace.
+   
+   - parameter action: the action for which you need the name.
+   - returns: the namespaced name of the Action
+   */
+  static func stringName(for action: AnyAction) -> String {
+    return String(reflecting:(type(of: action)))
+  }
+  
+  /**
+   This takes an Action.Type and returns the name of the action by considering its namespace.
+   
+   - parameter action: the action type for which you need the name.
+   - returns: the namespaced name of the Action.Type
+   */
+  static func stringName(for actionType: Action.Type) -> String {
+    return String(reflecting:actionType)
+  }
+  
+  /**
+   This function returns a StoreMiddleware that chains the actions defined as linked
+   
+   - see `StoreMiddleware` for details.
+   */
+  public static func middleware(for linkedActions: [ActionLinks]) -> StoreMiddleware {
+    
+    let reducedLinks = ActionLinker.reduceLinks(from: linkedActions)
+    
+    return { getState, dispatch in
+      return { next in
+        return { action in
+          
+          let oldState = getState()
+          next(action)
+          let newState = getState()
+          
+          ActionLinker.dispatchActions(
+            for: newState,
+            oldState: oldState,
+            sourceAction: action,
+            links: reducedLinks,
+            dispatch: dispatch
+          )
+        }
+      }
+    }
+  }
+}

--- a/Katana/Store/Middleware/ActionLinker/ActionLinks.swift
+++ b/Katana/Store/Middleware/ActionLinker/ActionLinks.swift
@@ -1,0 +1,26 @@
+//
+//  ActionLinks.swift
+//  Katana
+//
+//  Created by Riccardo Cipolleschi on 11/01/2017.
+//  Copyright © 2017 Bending Spoons. All rights reserved.
+//
+
+import Foundation
+
+/**
+ A struct that contains the link source and all the linked actions that depends on the first one.
+ */
+public struct ActionLinks {
+  
+  ///Action type that is the source of the link.
+  let source: Action.Type
+  
+  ///All the actions that must be dispatched after the source has been triggered.
+  let links: [LinkeableAction.Type]
+
+  init(source: Action.Type, links: [LinkeableAction.Type]) {
+    self.source = source
+    self.links = links
+  }
+}

--- a/Katana/Store/Middleware/ActionLinker/LinkeableAction.swift
+++ b/Katana/Store/Middleware/ActionLinker/LinkeableAction.swift
@@ -1,0 +1,52 @@
+//
+//  LinkeableAction.swift
+//  Katana
+//
+//  Created by Riccardo Cipolleschi on 11/01/2017.
+//  Copyright © 2017 Bending Spoons. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Protocol to identify a linked action that must be dispatched after another action, 
+ called source, is dispatched by the Store.
+ */
+public protocol LinkeableAction: Action {
+  /**
+   Failable initializer for the LinkedAction.
+   The parameters are used to choose if the action must effectively be created 
+   (and so executed) or not
+   
+   A typical implementation could be
+   ```
+   if <condition on new state or on old state>{
+    self = Action()
+    return
+   }
+   
+   return nil
+   ```
+   
+   In general, you should not save in the action the oldStore nor the newStore.
+   
+   in the case of an AsyncAction, you can use the sourceAction.state as a switch if you 
+   want to run the linkedAction when the source completes or fails.
+   
+   In this case the implementation could be
+   ```
+   if sourceAction.state == .completed && <condition on new state or on old state>{
+    self = Action()
+    return
+   }
+   
+   return nil
+   ```
+   
+   
+   - parameter oldState: the state of the application before the source action is applied
+   - parameter newState: the state of the application after the source action is applied
+   - parameter sourceAction: the action on which the LinkeableAction depends upon
+ */
+  init?(oldState: State, newState: State, sourceAction: Action)
+}

--- a/Katana/Store/Store.swift
+++ b/Katana/Store/Store.swift
@@ -141,6 +141,7 @@ open class Store<StateType: State> {
     self.dispatchQueue.async {
       self.dispatchFunction(action)
     }
+    
   }
 }
 

--- a/KatanaElements/MacOS/Button.swift
+++ b/KatanaElements/MacOS/Button.swift
@@ -19,7 +19,7 @@ public extension Button {
 
     public var backgroundColor: NSColor = .white
     public var backgroundHighlightedColor: NSColor?
-
+    public var cornerRadius: Value = .zero
     public var title: NSAttributedString = NSAttributedString()
     public var image: NSImage?
     public var highlightedImage: NSImage?
@@ -29,7 +29,7 @@ public extension Button {
     public init() {}
 
     public static func == (lhs: Props, rhs: Props) -> Bool {
-      // We can't detect whether clickHandler is changed
+      // We can't detect whether clickHandler is changed or not
       return false
     }
   }
@@ -54,6 +54,7 @@ public struct Button: NodeDescription, NodeDescriptionWithChildren {
     view.backgroundHighlightedColor = props.backgroundHighlightedColor ?? props.backgroundColor
     view.attributedTitle = props.title
     view.clickHandler = props.clickHandler
+    view.cornerRadius = props.cornerRadius.scale(by: node.plasticMultiplier)
   }
 
   public static func childrenDescriptions(props: Props,

--- a/KatanaElements/MacOS/Button.swift
+++ b/KatanaElements/MacOS/Button.swift
@@ -24,6 +24,7 @@ public extension Button {
     public var image: NSImage?
     public var highlightedImage: NSImage?
     public var clickHandler: ClickHandlerClosure?
+    public var isEnabled: Bool = true
     public var type: NSButtonType = NSMomentaryChangeButton
     
     public init() {}
@@ -49,6 +50,7 @@ public struct Button: NodeDescription, NodeDescriptionWithChildren {
     view.alpha = props.alpha
     view.frame = props.frame
     view.image = props.image
+    view.isEnabled = props.isEnabled
     view.alternateImage = props.highlightedImage
     view.backgroundColor = props.backgroundColor
     view.backgroundHighlightedColor = props.backgroundHighlightedColor ?? props.backgroundColor

--- a/KatanaElements/MacOS/NativeButton.swift
+++ b/KatanaElements/MacOS/NativeButton.swift
@@ -23,6 +23,12 @@ open class NativeButton: NSButton {
       self.needsDisplay = true
     }
   }
+  
+  open var cornerRadius: CGFloat = 0 {
+    didSet {
+      self.needsDisplay = true
+    }
+  }
 
   // MARK: - clickHandler
 
@@ -53,6 +59,7 @@ open class NativeButton: NSButton {
     } else {
       self.layer?.backgroundColor = self.backgroundColor.cgColor
     }
+    self.layer?.cornerRadius = self.cornerRadius
   }
 
   // MARK: - coordinate system

--- a/KatanaTests/Storage/Core/ActionLinkerTests.swift
+++ b/KatanaTests/Storage/Core/ActionLinkerTests.swift
@@ -1,0 +1,486 @@
+//
+//  ActionLinkerTests.swift
+//  Katana
+//
+//  Created by Riccardo Cipolleschi on 12/01/2017.
+//  Copyright © 2017 Bending Spoons. All rights reserved.
+//
+import Foundation
+import XCTest
+@testable import Katana
+
+class ActionLinkerTests: XCTestCase {
+  
+  override func setUp() {
+    super.setUp()
+  }
+    
+  override func tearDown() {
+    super.tearDown()
+  }
+
+  //MARK Creation tests
+  func testReduceNothing() {
+    let res = ActionLinker.reduceLinks(from: [])
+    XCTAssertTrue(res.isEmpty)
+  }
+  
+  func testReduceOneSourceActionOneLink() {
+    let res = ActionLinker.reduceLinks(from: [ActionLinks(source: BaseAction.self, links: [LinkedAction1.self])])
+    XCTAssertEqual(res.count, 1)
+    XCTAssertEqual(res[ActionLinker.stringName(for: BaseAction.self)]!.count, 1)
+    
+  }
+
+  func testCreationOneSourceActionTwoLinks() {
+    let res = ActionLinker.reduceLinks(from: [ActionLinks(source: BaseAction.self,
+                                                       links: [LinkedAction1.self, LinkedAction1.self])])
+    XCTAssertEqual(res.count, 1)
+    XCTAssertEqual(res[ActionLinker.stringName(for: BaseAction.self)]!.count, 2)
+  }
+  
+  func testCreationTwoSourceActionOneLink() {
+    let res = ActionLinker.reduceLinks(from: [ActionLinks(source: BaseAction.self, links: [LinkedAction1.self]),
+                                            ActionLinks(source: BaseAction2.self, links: [LinkedAction1.self])])
+    XCTAssertEqual(res.count, 2)
+    XCTAssertEqual(res[ActionLinker.stringName(for: BaseAction.self)]!.count, 1)
+    XCTAssertEqual(res[ActionLinker.stringName(for: BaseAction2.self)]!.count, 1)
+  }
+  
+  func testCreationTwoSameSourceActionOneLink() {
+    let res = ActionLinker.reduceLinks(from: [ActionLinks(source: BaseAction.self, links: [LinkedAction1.self]),
+                                            ActionLinks(source: BaseAction.self, links: [LinkedAction2.self])])
+    XCTAssertEqual(res.count, 1)
+    XCTAssertEqual(res[ActionLinker.stringName(for: BaseAction.self)]!.count, 2)
+  }
+  
+//MARK SyncAction
+  
+  func testNoChaining() {
+    let expectation = self.expectation(description: "Store listener")
+    
+    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: [])],
+                                            dependencies: EmptySideEffectDependencyContainer.self)
+    _ = store.addListener { expectation.fulfill() }
+    store.dispatch(BaseAction())
+    XCTAssertTrue(true)
+    
+    self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+      let newState = store.state
+      
+      XCTAssertEqual(newState.int, 20)
+    }
+  }
+  
+  func testOneChain() {
+    var count = 0
+    let expectation = self.expectation(description: "Store listener")
+    
+    let linksArray = [ActionLinks(source: BaseAction.self, links: [LinkedAction1.self])]
+    
+    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: linksArray)],
+                                            dependencies: EmptySideEffectDependencyContainer.self)
+    _ = store.addListener {
+      count += 1
+      if count == 2 {
+        expectation.fulfill()
+      }
+    }
+    
+    store.dispatch(BaseAction())
+    XCTAssertTrue(true)
+    
+    self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+      let newState = store.state
+      XCTAssertNotEqual(newState.int, 20)
+      XCTAssertEqual(newState.int, 10)
+    }
+  }
+  
+  func testOneChainDoubleLength() {
+    var count = 0
+    let expectation = self.expectation(description: "Store listener")
+    
+    let linksArray = [ActionLinks(source: BaseAction.self,
+                                  links: [LinkedAction1.self, LinkedAction1.self])]
+    
+    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: linksArray)],
+                                            dependencies: EmptySideEffectDependencyContainer.self)
+    _ = store.addListener {
+      count += 1
+      if count == 3 {
+        expectation.fulfill()
+      }
+    }
+    
+    store.dispatch(BaseAction())
+    XCTAssertTrue(true)
+    
+    self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+      let newState = store.state
+      XCTAssertNotEqual(newState.int, 20)
+      XCTAssertNotEqual(newState.int, 10)
+      XCTAssertEqual(newState.int, 5)
+    }
+  }
+  
+  func testOneChainWithTwoLinks() {
+    var count = 0
+    let expectation = self.expectation(description: "Store listener")
+    
+    let linksArray = [ActionLinks(source: BaseAction.self, links: [LinkedAction1.self]),
+                      ActionLinks(source: BaseAction.self, links: [LinkedAction1.self])]
+    
+    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: linksArray)],
+                                            dependencies: EmptySideEffectDependencyContainer.self)
+    _ = store.addListener {
+      count += 1
+      if count == 3 {
+        expectation.fulfill()
+      }
+    }
+    
+    store.dispatch(BaseAction())
+    XCTAssertTrue(true)
+    
+    self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+      let newState = store.state
+      XCTAssertNotEqual(newState.int, 20)
+      XCTAssertNotEqual(newState.int, 10)
+      XCTAssertEqual(newState.int, 5)
+    }
+  }
+  
+  func testTwoChains() {
+    var count = 0
+    let expectation = self.expectation(description: "Store listener")
+    
+    let linksArray = [ActionLinks(source: BaseAction.self, links: [LinkedAction1.self]),
+                      ActionLinks(source: BaseAction2.self, links: [LinkedAction1.self])]
+    
+    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: linksArray)],
+                                            dependencies: EmptySideEffectDependencyContainer.self)
+    _ = store.addListener {
+      count += 1
+      if count == 2 {
+        expectation.fulfill()
+      }
+    }
+    
+    store.dispatch(BaseAction())
+    XCTAssertTrue(true)
+    
+    self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+      let newState = store.state
+      
+      XCTAssertNotEqual(newState.int, 20)
+      XCTAssertEqual(newState.int, 10)
+      
+      //Chain 2
+      let expectation2 = self.expectation(description: "Store listener 2")
+      _ = store.addListener {
+        if count == 4 {
+          expectation2.fulfill()
+        }
+      }
+      store.dispatch(BaseAction2())
+      self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+        let newState = store.state
+        
+        XCTAssertNotEqual(newState.int, 10)
+        XCTAssertEqual(newState.int, 5)
+      }
+    }
+  }
+  
+  func testOneChainFailableActionSuccess() {
+    var count = 0
+    let expectation = self.expectation(description: "Store listener")
+    
+    let linksArray = [ActionLinks(source: BaseAction2.self, links: [LinkedAction3.self])]
+    
+    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: linksArray)],
+                                            dependencies: EmptySideEffectDependencyContainer.self)
+    _ = store.addListener {
+      count += 1
+      if count == 2 {
+        expectation.fulfill()
+      }
+    }
+    
+    store.dispatch(BaseAction2())
+    XCTAssertTrue(true)
+    
+    self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+      let newState = store.state
+      XCTAssertNotEqual(newState.int, 20)
+      XCTAssertEqual(newState.int, 100)
+    }
+  }
+  
+  func testOneChainFailableActionFailure() {
+    var count = 0
+    let expectation = self.expectation(description: "Store listener")
+    
+    let linksArray = [ActionLinks(source: BaseAction.self, links: [LinkedAction3.self])]
+    
+    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: linksArray)],
+                                            dependencies: EmptySideEffectDependencyContainer.self)
+    _ = store.addListener {
+      count += 1
+      if count == 1 {
+        expectation.fulfill()
+      }
+    }
+    
+    store.dispatch(BaseAction())
+    XCTAssertTrue(true)
+    
+    self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+      let newState = store.state
+      XCTAssertEqual(newState.int, 20)
+      XCTAssertNotEqual(newState.int, 100)
+    }
+  }
+  
+//MARK AsyncActions
+  
+  func testAsyncCompleted() {
+    var count = 0
+    let expectation = self.expectation(description: "Store listener")
+    
+    let linksArray = [ActionLinks(source: BaseAsyncAction.self, links: [LinkedAction4.self])]
+    
+    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: linksArray)],
+                                            dependencies: EmptySideEffectDependencyContainer.self)
+    _ = store.addListener {
+      count += 1
+      if count == 2 {
+        expectation.fulfill()
+      }
+    }
+    
+    var baseAsyncAction = BaseAsyncAction(payload: 10).completedAction(payload: 100)
+    baseAsyncAction.invokedCompletedClosure = {
+      count += 1
+    }
+    baseAsyncAction.invokedFailedClosure = {
+      count += 1
+    }
+    
+    store.dispatch(baseAsyncAction)
+    
+    XCTAssertTrue(true)
+    
+    self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+      let newState = store.state
+      XCTAssertNotEqual(newState.int, 100)
+      XCTAssertEqual(newState.int, 10)
+    }
+  }
+  
+  func testAsyncFailed() {
+    var count = 0
+    let expectation = self.expectation(description: "Store listener")
+    
+    let linksArray = [ActionLinks(source: BaseAsyncAction.self, links: [LinkedAction5.self])]
+    
+    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: linksArray)],
+                                            dependencies: EmptySideEffectDependencyContainer.self)
+    _ = store.addListener {
+      count += 1
+      if count == 2 {
+        expectation.fulfill()
+      }
+    }
+    
+    var baseAsyncAction = BaseAsyncAction(payload: 10).failedAction(payload: -100)
+    baseAsyncAction.invokedCompletedClosure = {
+      count += 1
+    }
+    baseAsyncAction.invokedFailedClosure = {
+      count += 1
+    }
+    
+    store.dispatch(baseAsyncAction)
+    
+    XCTAssertTrue(true)
+    
+    self.waitForExpectations(timeout: 2.0) { (err: Error?) in
+      let newState = store.state
+      XCTAssertNotEqual(newState.int, -100)
+      XCTAssertEqual(newState.int, 10)
+    }
+  }
+  
+}
+
+//MARK Mocking
+fileprivate struct ActionLinkerAppState: State {
+  var int: Int = 0
+}
+
+fileprivate struct BaseAction: Action {
+  func updatedState(currentState: State) -> State {
+    var newState = currentState as! ActionLinkerAppState
+    newState.int = 20
+    return newState
+  }
+}
+
+fileprivate struct BaseAction2: Action {
+  func updatedState(currentState: State) -> State {
+    var newState = currentState as! ActionLinkerAppState
+    newState.int = 10
+    return newState
+  }
+}
+
+fileprivate struct LinkedAction1: LinkeableAction {
+  init() {
+    
+  }
+  
+  init?(oldState: State, newState: State, sourceAction: Action) {
+    self = LinkedAction1()
+  }
+  
+  func updatedState(currentState: State) -> State {
+    var newState = currentState as! ActionLinkerAppState
+    newState.int = newState.int/2
+    return newState
+  }
+}
+
+fileprivate struct LinkedAction2: LinkeableAction {
+  init() {
+    
+  }
+  
+  init?(oldState: State, newState: State, sourceAction: Action) {
+    self = LinkedAction2()
+  }
+  
+  func updatedState(currentState: State) -> State {
+    var newState = currentState as! ActionLinkerAppState
+    newState.int = newState.int*2
+    return newState
+  }
+  
+}
+
+fileprivate struct LinkedAction3: LinkeableAction {
+  init() {
+    
+  }
+  
+  init?(oldState: State, newState: State, sourceAction: Action) {
+    let currentState = newState as! ActionLinkerAppState
+    if currentState.int <= 10 {
+      self = LinkedAction3()
+      return
+    }
+    return nil
+  }
+  
+  func updatedState(currentState: State) -> State {
+    var newState = currentState as! ActionLinkerAppState
+    newState.int = 100
+    return newState
+  }
+}
+
+//MARK Mocking for the async testing
+
+fileprivate struct BaseAsyncAction: AsyncAction {
+
+  public init(payload: Int) {
+    self.loadingPayload = payload
+    self.failedPayload = nil
+    self.completedPayload = nil
+    self.state = .loading
+  }
+  
+  typealias LoadingPayload = Int
+  typealias CompletedPayload = Int
+  typealias FailedPayload = Int
+  
+  /// The loading payload of the action
+  public var loadingPayload: Int
+  public var failedPayload: Int?
+  public var completedPayload: Int?
+
+  /// The state of the action
+  public var state: AsyncActionState
+
+  var invokedLoadingClosure: () -> () = { _ in }
+  var invokedCompletedClosure: () -> () = { _ in }
+  var invokedFailedClosure: () -> () = { _ in }
+  
+  func updatedStateForLoading(currentState: State) -> State {
+    self.invokedLoadingClosure()
+    return currentState
+  }
+
+  func updatedStateForCompleted(currentState: State) -> State {
+    var newState = currentState as! ActionLinkerAppState
+    newState.int = 100
+    self.invokedCompletedClosure()
+    return newState
+  }
+  
+  func updatedStateForFailed(currentState: State) -> State {
+    var newState = currentState as! ActionLinkerAppState
+    newState.int = -100
+    self.invokedFailedClosure()
+    return newState
+  }
+}
+
+fileprivate struct LinkedAction4: LinkeableAction {
+  init() {
+    
+  }
+  
+  init?(oldState: State, newState: State, sourceAction: Action) {
+    guard let source = sourceAction as? BaseAsyncAction else {
+      return nil
+    }
+    
+    if source.state == .completed {
+      self = LinkedAction4()
+      return
+    }
+    return nil
+  }
+  
+  func updatedState(currentState: State) -> State {
+    var newState = currentState as! ActionLinkerAppState
+    newState.int /= 10
+    return newState
+  }
+}
+
+fileprivate struct LinkedAction5: LinkeableAction {
+  init() {
+    
+  }
+  
+  init?(oldState: State, newState: State, sourceAction: Action) {
+    guard let source = sourceAction as? BaseAsyncAction else {
+      return nil
+    }
+    
+    if source.state == .failed {
+      self = LinkedAction5()
+      return
+    }
+    return nil
+  }
+
+  func updatedState(currentState: State) -> State {
+    var newState = currentState as! ActionLinkerAppState
+    newState.int /= -10
+    return newState
+  }
+}


### PR DESCRIPTION
# Changes

### Core

* `scaleValue` is now a public function of `PlasticView`
* Implement [Linkable Actions](https://github.com/BendingSpoons/katana-swift/pull/98)

### MacOS

* Improve `Button`
  *  `cornerRadius` can now be customized
  *  `isEnabled` can now be customized

# Breaking Changes

### Core

* It is not possible to invoke `dispatch` and `update` asynchronously in the lifecyle hooks. This required to change the signatures of the methods by adding the `@escaping` parameter