### PR TITLE
Make the ActionLinks init public

### DIFF
--- a/Katana/Store/Middleware/ActionLinker/ActionLinks.swift
+++ b/Katana/Store/Middleware/ActionLinker/ActionLinks.swift
@@ -19,7 +19,14 @@ public struct ActionLinks {
   ///All the actions that must be dispatched after the source has been triggered.
   let links: [LinkeableAction.Type]
 
-  init(source: Action.Type, links: [LinkeableAction.Type]) {
+  /**
+   Initializer to create an ActionLinks.
+   It must be public so other libs can export their own links.
+   
+   - parameter source: the Action.Type that is the source of the link.
+   - parameter links: the array of dependant actions that should be invoked after the first.
+   */
+  public init(source: Action.Type, links: [LinkeableAction.Type]) {
     self.source = source
     self.links = links
   }


### PR DESCRIPTION
**Why**
ActionLinks init was not public. In that case, other libs cannot init the ActionLinks they want to export.
Now they can.

**Changes**
ActionLinks init is now public.

**Tasks**
* [ ] Add relevant tests, if needed
* [X] Add documentation, if needed
* [ ] Update README, if needed
* [X] Ensure that all the examples (as well as the demo) work properly