### PR TITLE
Side effects refactor

### DIFF
--- a/Demo/IOS/UI/CounterScreen.swift
+++ b/Demo/IOS/UI/CounterScreen.swift
@@ -50,10 +50,10 @@ struct CounterScreen: ConnectedNodeDescription, PlasticNodeDescription, PlasticR
         $0.setKey(Keys.decrementButton)
         $0.titles[.normal] = "Decrement"
         $0.backgroundColor = .dogwoodRose
-        $0.titleColors = [.highlighted : .jet]
+        $0.titleColors = [.highlighted: .jet]
 
         $0.touchHandlers = [
-          .touchUpInside : {
+          .touchUpInside: {
             dispatch(DecrementCounter())
           }
         ]
@@ -62,10 +62,10 @@ struct CounterScreen: ConnectedNodeDescription, PlasticNodeDescription, PlasticR
         $0.setKey(Keys.incrementButton)
         $0.titles[.normal] = "Increment"
         $0.backgroundColor = .japaneseIndigo
-        $0.titleColors = [.highlighted : .jet]
+        $0.titleColors = [.highlighted: .jet]
 
         $0.touchHandlers = [
-          .touchUpInside : {
+          .touchUpInside: {
             dispatch(IncrementCounter())
           }
         ]

--- a/Examples/CodingLove/CodingLove/Actions/FetchMorePosts.swift
+++ b/Examples/CodingLove/CodingLove/Actions/FetchMorePosts.swift
@@ -10,7 +10,6 @@ import Foundation
 import Katana
 
 struct FetchMorePosts: AsyncAction, ActionWithSideEffect {
-    
     public struct CompletedActionPayload {
         var posts: [Post]
         var allFetched: Bool = false
@@ -56,26 +55,26 @@ struct FetchMorePosts: AsyncAction, ActionWithSideEffect {
     }
   
     public func sideEffect(
-        state: State,
-        dispatch: @escaping StoreDispatch,
-        dependencies: SideEffectDependencyContainer
-    ) {
-        
-        let castedState = state as! CodingLoveState
-        let page: Int = castedState.page
-        
-        let postsProvider = dependencies as! PostsProvider
-        
-        postsProvider.fetchPosts(for: page) { (result, errorMessage) in
-            if let data = result {
-                let (posts, allFetched) = data
-                dispatch(self.completedAction {
-                  $0.completedPayload = CompletedActionPayload(posts: posts, allFetched: allFetched)
-                })
-            
-            } else {
-                dispatch(self.failedAction { $0.failedPayload = errorMessage! })
-            }
+      currentState: State,
+      previousState: State,
+      dispatch: @escaping StoreDispatch,
+      dependencies: SideEffectDependencyContainer) {
+    
+      let castedState = currentState as! CodingLoveState
+      let page: Int = castedState.page
+      
+      let postsProvider = dependencies as! PostsProvider
+      
+      postsProvider.fetchPosts(for: page) { (result, errorMessage) in
+        if let data = result {
+          let (posts, allFetched) = data
+          dispatch(self.completedAction {
+            $0.completedPayload = CompletedActionPayload(posts: posts, allFetched: allFetched)
+          })
+          
+        } else {
+          dispatch(self.failedAction { $0.failedPayload = errorMessage! })
         }
+      }
     }
 }

--- a/Examples/CodingLove/CodingLove/Providers/PostsProvider.swift
+++ b/Examples/CodingLove/CodingLove/Providers/PostsProvider.swift
@@ -11,12 +11,8 @@ import Katana
 
 let postsPerPage = 3
 
-struct PostsProvider: SideEffectDependencyContainer {
-    var posts: [Post]
-    
-    public init(state: State, dispatch: @escaping StoreDispatch) {
-        self.posts = [Post]()
-    }
+class PostsProvider: SideEffectDependencyContainer {
+    public required init(dispatch: @escaping StoreDispatch) {}
     
     public func fetchPosts(for page: Int, completion: @escaping (([Post], Bool)?, String?) -> ()) {
         DispatchQueue.global().async {

--- a/Katana/Store/ActionWithSideEffect.swift
+++ b/Katana/Store/ActionWithSideEffect.swift
@@ -19,7 +19,7 @@ import Foundation
  interact with disk, network and so on.
  
  ### Dependencies
- You can see from the `sideEffect(state:dispatch:dependencies:)` signature that
+ You can see from the `sideEffect(currentState:previousState:dispatch:dependencies:)` signature that
  a side effect takes as input some dependencies. This is a form of dependency injection
  for the side effects. By using only methods coming from the dependencies (instead of relying on
  global imports), testing is much more easier since you can inject a mocked version
@@ -35,14 +35,18 @@ import Foundation
 public protocol ActionWithSideEffect: Action {
   /**
    Performs the side effect. This method is invoked when the action is dispatched,
-   before it goes in the `updateState(currentState:action:)` function.
+   after the `updateState(currentState:action:)` function.
    
-   - parameter state:         the current state
-   - parameter dispatch:      a closure that can be used to dispatch new actions
-   - parameter dependencies:  the dependencies of the side effect
+   - parameter currentState:    the current state. The one returned by the
+                                `updateState(currentState:action:)` method
+   - parameter previousState:   the state of the store before the `updateState(currentState:action:)`
+                                invokation
+   - parameter dispatch:        a closure that can be used to dispatch new actions
+   - parameter dependencies:    the dependencies of the side effect
   */
   func sideEffect(
-    state: State,
+    currentState: State,
+    previousState: State,
     dispatch: @escaping StoreDispatch,
     dependencies: SideEffectDependencyContainer
   )

--- a/Katana/Store/ActionWithSideEffect.swift
+++ b/Katana/Store/ActionWithSideEffect.swift
@@ -26,11 +26,6 @@ import Foundation
  of the things you need in the side effect. For example, in a test, you may want to
  inject a mocked version of the class that manages the API requests, in order to control
  the result of the network call.
- 
- Every time a side effect is triggered, the dependencies (or better, the `SideEffectDependencyContainer`)
- is instantiated from scratch. We do this to avoid that pieces of state are saved in the managers or
- in the classes that there are in the dependencies, since we want to store all the relevant
- information in the `Store`
 */
 public protocol ActionWithSideEffect: Action {
   /**

--- a/Katana/Store/ActionWithSideEffect.swift
+++ b/Katana/Store/ActionWithSideEffect.swift
@@ -14,7 +14,7 @@ import Foundation
  
  A side effect is nothing more than a piece of code that can interact with external
  services or APIs (e.g., make a network request, get information from the disk and so on).
- Side effects are needed because the `updateState(currentState:)` function (which is the only other operation
+ Side effects are needed because the `updatedState(currentState:)` function (which is the only other operation
  that is performed when an action is dispatched) must be pure and therefore it cannot
  interact with disk, network and so on.
  

--- a/Katana/Store/SideEffectDependencyContainer.swift
+++ b/Katana/Store/SideEffectDependencyContainer.swift
@@ -8,29 +8,25 @@
 
 import Foundation
 
-/**
- Protocol that the side effect dependencies container should implement
-*/
-public protocol SideEffectDependencyContainer {
+/// Protocol that the side effect dependencies container should implement
+public protocol SideEffectDependencyContainer: class {
   /**
    Creates a new instance of the container.
-   A new container is created every time a side effect is invoked
+   The container is instantiated when the store is instantiated
    
-   - parameter state:     the current state
    - parameter dispatch:  a closure that can be used to dispatch actions
    - returns: an instance of the container
   */
-  init(state: State, dispatch: @escaping StoreDispatch)
+  init(dispatch: @escaping StoreDispatch)
 }
 
 /// An empty dependencies container. It can be used for testing purposes or you don't need dependencies
-public struct EmptySideEffectDependencyContainer: SideEffectDependencyContainer {
+public class EmptySideEffectDependencyContainer: SideEffectDependencyContainer {
   /**
-   Creates the empty dependency container
+   Creates an empty dependency container
    
-   - parameter state:     the current state
    - parameter dispatch:  a closure that can be used to dispatch actions
    - returns: an instance of the container
   */
-  public init(state: State, dispatch: @escaping StoreDispatch) {}
+  public required init(dispatch: @escaping StoreDispatch) {}
 }

--- a/Katana/Store/Store.swift
+++ b/Katana/Store/Store.swift
@@ -66,7 +66,7 @@ open class Store<StateType: State> {
    
    - seeAlso: `ActionWithSideEffect`
   */
-  fileprivate let dependencies: SideEffectDependencyContainer.Type
+  fileprivate var dependencies: SideEffectDependencyContainer!
 
   /**
     The internal dispatch function. It combines all the operations that should be done when an action is dispatched.
@@ -101,8 +101,6 @@ open class Store<StateType: State> {
     self.listeners = []
     self.state = StateType()
     self.middleware = middleware
-    self.dependencies = dependencies
-    
     // create the dispatch function
 
     let getState = { [unowned self] () -> StateType in
@@ -114,6 +112,7 @@ open class Store<StateType: State> {
     }
     
     self.dispatchFunction = self.composeMiddlewares(m, with: self.performDispatch)
+    self.dependencies = dependencies.init(dispatch: self.dispatchFunction)
   }
 
   /**
@@ -216,14 +215,11 @@ fileprivate extension Store {
       return
     }
 
-    let dispatch = self.dispatch
-    let container = self.dependencies.init(state: state, dispatch: dispatch)
-
     action.sideEffect(
       currentState: currentState,
       previousState: previousState,
-      dispatch: dispatch,
-      dependencies: container
+      dispatch: self.dispatch,
+      dependencies: self.dependencies
     )
   }
 }

--- a/KatanaTests/Storage/Core/AsyncActionTests.swift
+++ b/KatanaTests/Storage/Core/AsyncActionTests.swift
@@ -46,10 +46,12 @@ fileprivate struct AsyncTestAction: AsyncAction, ActionWithSideEffect {
     self.invokedProgressClosure(self.state.progressPercentage!)
     return currentState
   }
-
-  func sideEffect(state: State,
-                  dispatch: @escaping StoreDispatch,
-                  dependencies: SideEffectDependencyContainer) {
+  
+  public func sideEffect(
+    currentState: State,
+    previousState: State,
+    dispatch: @escaping StoreDispatch,
+    dependencies: SideEffectDependencyContainer) {
 
     self.invokedSideEffectClosure()
   }

--- a/KatanaTests/Storage/Core/SideEffectTests.swift
+++ b/KatanaTests/Storage/Core/SideEffectTests.swift
@@ -16,7 +16,7 @@ class SideEffectTests: XCTestCase {
     var invoked = false
     let expectation = self.expectation(description: "Side effect")
 
-    let action = SpyActionWithSideEffect(sideEffectInvokedClosure: { (_, _, _) in
+    let action = SpyActionWithSideEffect(sideEffectInvokedClosure: { (_, _, _, _) in
       invoked = true
       expectation.fulfill()
     }, updatedInvokedClosure: nil)
@@ -32,14 +32,16 @@ class SideEffectTests: XCTestCase {
 
   func testSideEffectInvokedWithProperParameters() {
     var invoked = false
-    var invokedState: AppState?
+    var invokedCurrentState: AppState?
+    var invokedPreviousState: AppState?
     var invokedContainer: SideEffectDependencyContainer?
 
     let expectation = self.expectation(description: "Side effect")
 
-    let action = SpyActionWithSideEffect(sideEffectInvokedClosure: { (state, _, dependencyContainer)  in
+    let action = SpyActionWithSideEffect(sideEffectInvokedClosure: { (currentState, previousState, _, dependencyContainer)  in
       invoked = true
-      invokedState = state as? AppState
+      invokedCurrentState = currentState as? AppState
+      invokedPreviousState = previousState as? AppState
       invokedContainer = dependencyContainer
       expectation.fulfill()
     }, updatedInvokedClosure: nil)
@@ -51,7 +53,8 @@ class SideEffectTests: XCTestCase {
     self.waitForExpectations(timeout: 10) { (error) in
       XCTAssertNil(error)
       XCTAssert(invoked)
-      XCTAssertEqual(initialState, invokedState)
+      XCTAssertEqual(initialState, invokedPreviousState)
+      XCTAssertEqual(store.state, invokedCurrentState)
       XCTAssertNotNil(invokedContainer as? EmptySideEffectDependencyContainer)
     }
   }
@@ -61,7 +64,7 @@ class SideEffectTests: XCTestCase {
 
     let expectation = self.expectation(description: "Side effect")
 
-    let action = SpyActionWithSideEffect(sideEffectInvokedClosure: { (state, _, dependencyContainer)  in
+    let action = SpyActionWithSideEffect(sideEffectInvokedClosure: { (currentState, previousState, _, dependencyContainer)  in
       invokedContainer = dependencyContainer
       expectation.fulfill()
 
@@ -87,14 +90,14 @@ class SideEffectTests: XCTestCase {
     let action1expectation = self.expectation(description: "Action1")
     let action2expectation = self.expectation(description: "Action2")
 
-    let action2 = SpyActionWithSideEffect(sideEffectInvokedClosure: { (_, _, _) in
+    let action2 = SpyActionWithSideEffect(sideEffectInvokedClosure: { (_, _, _, _) in
       invocationOrder.append("side effect 2")
     }) {
       invocationOrder.append("update state 2")
       action2expectation.fulfill()
     }
 
-    let action1 = SpyActionWithSideEffect(sideEffectInvokedClosure: { (_, dispatch, _) in
+    let action1 = SpyActionWithSideEffect(sideEffectInvokedClosure: { (_, _, dispatch, _) in
       invocationOrder.append("side effect 1")
       dispatch(action2)
     }) {

--- a/KatanaTests/Storage/Core/SideEffectTests.swift
+++ b/KatanaTests/Storage/Core/SideEffectTests.swift
@@ -109,7 +109,7 @@ class SideEffectTests: XCTestCase {
       XCTAssertNil(error)
 
       XCTAssertEqual(invocationOrder, [
-        "side effect 1", "update state 1", "side effect 2", "update state 2"
+        "update state 1", "side effect 1", "update state 2", "side effect 2"
       ])
     }
   }

--- a/KatanaTests/Storage/Models/Actions.swift
+++ b/KatanaTests/Storage/Models/Actions.swift
@@ -55,7 +55,8 @@ struct SyncAddTodoAction: Action {
 
 struct SpyActionWithSideEffect: ActionWithSideEffect {
   typealias ActionWithSideEffectCallback = (
-    _ state: State,
+    _ currentState: State,
+    _ previousState: State,
     _ dispatch: @escaping StoreDispatch,
     _ dependencies: SideEffectDependencyContainer) -> ()
 
@@ -66,11 +67,13 @@ struct SpyActionWithSideEffect: ActionWithSideEffect {
     self.updatedInvokedClosure?()
     return currentState
   }
-
-  func sideEffect(state: State,
-                         dispatch: @escaping StoreDispatch,
-                         dependencies: SideEffectDependencyContainer
-    ) {
-    self.sideEffectInvokedClosure?(state, dispatch, dependencies)
+  
+  public func sideEffect(
+    currentState: State,
+    previousState: State,
+    dispatch: @escaping StoreDispatch,
+    dependencies: SideEffectDependencyContainer) {
+    
+    self.sideEffectInvokedClosure?(currentState, previousState, dispatch, dependencies)
   }
 }

--- a/KatanaTests/Storage/Models/DependencyContainer.swift
+++ b/KatanaTests/Storage/Models/DependencyContainer.swift
@@ -10,14 +10,5 @@ import Foundation
 import Katana
 
 class SimpleDependencyContainer: SideEffectDependencyContainer {
-  let state: AppState?
-
-  public required init(state: State, dispatch: @escaping StoreDispatch) {
-    if let s = state as? AppState {
-      self.state = s
-
-    } else {
-      self.state = nil
-    }
-  }
+  public required init(dispatch: @escaping StoreDispatch) {}
 }


### PR DESCRIPTION
**Why**
As discussed, this PR refactors the side effects. Se commits for more information, they have comments about reasons and changes

**Changes**
* The dependencies container doesn't take the state anymore as input
* The dependencies container is now forced to be a class
* The dependencies container is instantiated when the store is instantiated and not every time like ti was before
* Side effects are now triggered **after** the `updatedState` method
* Side effects now receive the current state (that is, the state after the `updatedState`) and the previous state (that is, the state before the `updatedState`)

**Tasks**
* [x] Add relevant tests, if needed
* [x] Add documentation, if needed
* [x] Update README, if needed
* [x] Ensure that all the examples (as well as the demo) work properly