### PR TITLE
Expose `borderColor` and `borderWidth` on Button

### DIFF
--- a/KatanaElements/MacOS/Button.swift
+++ b/KatanaElements/MacOS/Button.swift
@@ -19,6 +19,8 @@ public extension Button {
 
     public var backgroundColor: NSColor = .white
     public var backgroundHighlightedColor: NSColor?
+    public var borderColor: NSColor = .clear
+    public var borderWidth: Value = .zero
     public var cornerRadius: Value = .zero
     public var title: NSAttributedString = NSAttributedString()
     public var toolTip: String?
@@ -57,6 +59,8 @@ public struct Button: NodeDescription, NodeDescriptionWithChildren {
     view.backgroundHighlightedColor = props.backgroundHighlightedColor ?? props.backgroundColor
     view.attributedTitle = props.title
     view.clickHandler = props.clickHandler
+    view.borderColor = props.borderColor
+    view.borderWidth = props.borderWidth.scale(by: node.plasticMultiplier)
     view.cornerRadius = props.cornerRadius.scale(by: node.plasticMultiplier)
     view.toolTip = props.toolTip
   }

--- a/KatanaElements/MacOS/NativeButton.swift
+++ b/KatanaElements/MacOS/NativeButton.swift
@@ -24,6 +24,18 @@ open class NativeButton: NSButton {
     }
   }
   
+  open var borderColor: NSColor = NSColor.clear {
+    didSet {
+      self.needsDisplay = true
+    }
+  }
+  
+  open var borderWidth: CGFloat = 0 {
+    didSet {
+      self.needsDisplay = true
+    }
+  }
+  
   open var cornerRadius: CGFloat = 0 {
     didSet {
       self.needsDisplay = true
@@ -59,6 +71,8 @@ open class NativeButton: NSButton {
     } else {
       self.layer?.backgroundColor = self.backgroundColor.cgColor
     }
+    self.layer?.borderColor = self.borderColor.cgColor
+    self.layer?.borderWidth = self.borderWidth
     self.layer?.cornerRadius = self.cornerRadius
   }
 


### PR DESCRIPTION
**Why**
This PR exposes the `borderColor` and `borderWidth` properties on the Button element.