### PR TITLE
Fix Table Example

### DIFF
--- a/Examples/CodingLove/CodingLove/Providers/PostsProvider.swift
+++ b/Examples/CodingLove/CodingLove/Providers/PostsProvider.swift
@@ -12,8 +12,8 @@ import Katana
 let postsPerPage = 3
 
 class PostsProvider: SideEffectDependencyContainer {
-    public required init(dispatch: @escaping StoreDispatch) {}
-    
+    public required init(dispatch: @escaping StoreDispatch, getState: @escaping () -> State) {}
+
     public func fetchPosts(for page: Int, completion: @escaping (([Post], Bool)?, String?) -> ()) {
         DispatchQueue.global().async {
             let posts = Bundle.main.path(forResource: "posts", ofType: "json")


### PR DESCRIPTION
**Why**
There is a bug on master that prevents [Table Example](https://github.com/BendingSpoons/katana-swift/blob/master/Examples/CodingLove) from compiling in Xcode 8.2.1 with Swift 3.0.2.

**Changes**
Tiny fix applied that fixes `PostsProvider` conformance to `SideEffectDependencyContainer` protocol.

**Tasks**
* [x] Ensure that Table Example compiles

**Notice**
Please, take in mind that I am new to Katana and have very basic knowledge about it. My change fixed the compile error issue, but I am not sure if does not introduce some regression.