### PR TITLE
State Mock Feature

### DIFF
--- a/Katana.xcodeproj/project.pbxproj
+++ b/Katana.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		A1F8E2D91E90EEE400243FCB /* StateMockProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8E2D81E90EEE400243FCB /* StateMockProvider.swift */; };
 		A1F8E2DC1E90F9D500243FCB /* StateMockProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8E2DA1E90F9A800243FCB /* StateMockProviderTests.swift */; };
 		A1F8E2DD1E90F9D600243FCB /* StateMockProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8E2DA1E90F9A800243FCB /* StateMockProviderTests.swift */; };
+		A1F8E2DE1E9120F300243FCB /* StateMockProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8E2D81E90EEE400243FCB /* StateMockProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1436,6 +1437,7 @@
 				65BF2E8D1DE339C900441784 /* ActionWithSideEffect.swift in Sources */,
 				5115A6FF1E27C5DC007EA0FB /* ActionLinks.swift in Sources */,
 				65BF2EA11DE3639600441784 /* NSView+PlatformNativeView.swift in Sources */,
+				A1F8E2DE1E9120F300243FCB /* StateMockProvider.swift in Sources */,
 				65BF2E8E1DE339C900441784 /* SideEffectDependencyContainer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Katana.xcodeproj/project.pbxproj
+++ b/Katana.xcodeproj/project.pbxproj
@@ -200,6 +200,9 @@
 		A1CA315D1DC3A24000982BE9 /* AsyncAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CA315C1DC3A24000982BE9 /* AsyncAction.swift */; };
 		A1CF3BB91E2FB935007C9E0E /* NodeDescriptionShouldUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CF3BB71E2FB7F0007C9E0E /* NodeDescriptionShouldUpdateTests.swift */; };
 		A1F88CD31DD0C040004A8285 /* AnimationContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F88CD21DD0C040004A8285 /* AnimationContainer.swift */; };
+		A1F8E2D91E90EEE400243FCB /* StateMockProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8E2D81E90EEE400243FCB /* StateMockProvider.swift */; };
+		A1F8E2DC1E90F9D500243FCB /* StateMockProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8E2DA1E90F9A800243FCB /* StateMockProviderTests.swift */; };
+		A1F8E2DD1E90F9D600243FCB /* StateMockProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F8E2DA1E90F9A800243FCB /* StateMockProviderTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -404,6 +407,8 @@
 		A1CA315C1DC3A24000982BE9 /* AsyncAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncAction.swift; sourceTree = "<group>"; };
 		A1CF3BB71E2FB7F0007C9E0E /* NodeDescriptionShouldUpdateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeDescriptionShouldUpdateTests.swift; sourceTree = "<group>"; };
 		A1F88CD21DD0C040004A8285 /* AnimationContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationContainer.swift; sourceTree = "<group>"; };
+		A1F8E2D81E90EEE400243FCB /* StateMockProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateMockProvider.swift; sourceTree = "<group>"; };
+		A1F8E2DA1E90F9A800243FCB /* StateMockProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateMockProviderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -522,6 +527,7 @@
 			isa = PBXGroup;
 			children = (
 				813315281D7B726000FBE210 /* Renderer.swift */,
+				A1F8E2D81E90EEE400243FCB /* StateMockProvider.swift */,
 			);
 			path = Renderer;
 			sourceTree = "<group>";
@@ -790,6 +796,7 @@
 				81911D9F1D7D916B00123C54 /* RenderContainersTest.swift */,
 				A19385461E0D1F2100F436D6 /* NodeDescriptionLifecycleTests.swift */,
 				A1CF3BB71E2FB7F0007C9E0E /* NodeDescriptionShouldUpdateTests.swift */,
+				A1F8E2DA1E90F9A800243FCB /* StateMockProviderTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1446,6 +1453,7 @@
 				65BF2EF21DE8301E00441784 /* NodeDescriptionTest.swift in Sources */,
 				65BF2EF31DE8301E00441784 /* NodeTest.swift in Sources */,
 				65BF2EF41DE8301E00441784 /* RenderContainersTest.swift in Sources */,
+				A1F8E2DD1E90F9D600243FCB /* StateMockProviderTests.swift in Sources */,
 				65BF2EF51DE8301E00441784 /* Collections.swift in Sources */,
 				65BF2EF61DE8301E00441784 /* HierarchyManagers.swift in Sources */,
 				65BF2EF71DE8301E00441784 /* PlasticBasicLayoutTests.swift in Sources */,
@@ -1515,6 +1523,7 @@
 				65A7223B1DDF5BAF00013E7A /* PlatformNativeView.swift in Sources */,
 				8179CAFB1DDE5F3C000C2164 /* Int+Katana.swift in Sources */,
 				A1C9C1C31DD32D570067F8E0 /* InternalNode.swift in Sources */,
+				A1F8E2D91E90EEE400243FCB /* StateMockProvider.swift in Sources */,
 				A1C9C1CD1DD36BE50067F8E0 /* Animation.swift in Sources */,
 				8133155C1D7B726000FBE210 /* Node.swift in Sources */,
 				A1CA31551DC37DBF00982BE9 /* StoreTypealiases.swift in Sources */,
@@ -1556,6 +1565,7 @@
 				A1576C2D1DC72E03008281C0 /* SideEffectTests.swift in Sources */,
 				A16A746E1DD3DD1200C9560D /* Actions.swift in Sources */,
 				81911DBF1D7D916B00123C54 /* PlasticDimensionsTests.swift in Sources */,
+				A1F8E2DC1E90F9D500243FCB /* StateMockProviderTests.swift in Sources */,
 				81911DBB1D7D916B00123C54 /* HierarchyManagers.swift in Sources */,
 				81911DBC1D7D916B00123C54 /* PlasticBasicLayoutTests.swift in Sources */,
 				81911DC21D7D916B00123C54 /* MiddlewareTests.swift in Sources */,

--- a/Katana/Core/Node/Node+AnyNode.swift
+++ b/Katana/Core/Node/Node+AnyNode.swift
@@ -37,7 +37,12 @@ extension Node: AnyNode {
       fatalError("Impossible to use the provided description to update the node")
     }
 
-    description.props = self.updatedPropsWithConnect(description: description, props: description.props)
+    description.props = Node.updatedPropsWithConnect(
+      description: description,
+      props: description.props,
+      store: self.renderer?.store
+    )
+
     self.update(for: self.state, description: description, animation: animation, completion: completion)
   }
 

--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -74,9 +74,6 @@ public class Node<Description: NodeDescription> {
    */
   fileprivate weak var myRenderer: Renderer?
   
-  /// Whether the state is mocked
-  fileprivate let isStateMocked: Bool
-  
   fileprivate var storeDispatch: StoreDispatch {
     return self.renderer?.store?.dispatch ?? { fatalError("\($0) cannot be dispatched. Store not avaiable.") }
   }
@@ -143,11 +140,9 @@ public class Node<Description: NodeDescription> {
       let mockedState = stateMockProvider.state(for: Description.self, props: self.description.props) {
       
       self.state = mockedState
-      self.isStateMocked = true
       
     } else {
       self.state = Description.StateType()
-      self.isStateMocked = false
     }
     
     self.childrenDescriptions  = self.processedChildrenDescriptionsBeforeDraw(
@@ -392,11 +387,6 @@ extension Node {
    - parameter state: the new state
    */
   func update(for state: Description.StateType) {
-    guard !self.isStateMocked else {
-      // state shuldn't change because of internal updates if the state is mocked
-      return
-    }
-
     self.update(for: state, description: self.description, animation: .none)
   }
   
@@ -423,7 +413,6 @@ extension Node {
     let stateToUse: Description.StateType
       
     if
-      self.isStateMocked,
       let provider = self.renderer?.stateMockProvider,
       let mockedState = provider.state(for: Description.self, props: description.props) {
       

--- a/Katana/Core/Renderer/Renderer.swift
+++ b/Katana/Core/Renderer/Renderer.swift
@@ -51,6 +51,7 @@ open class Renderer {
    
    - parameter rootDescription: the root node description
    - parameter store: the store of the application
+   - parameter stateMockProvider: an optional `StateMockProvider` that can be used to mock the internal states
    - returns: An instance of Renderer that manages rendering and store updates
   */
   public init(rootDescription: AnyNodeDescription, store: AnyStore?, stateMockProvider: StateMockProvider? = nil) {

--- a/Katana/Core/Renderer/Renderer.swift
+++ b/Katana/Core/Renderer/Renderer.swift
@@ -26,6 +26,9 @@ import Foundation
 open class Renderer {
   /// The store that is used in the application
   public let store: AnyStore?
+  
+  /// The state mock provider to use in the application
+  let stateMockProvider: StateMockProvider?
 
   /**
     Reference to the Root's child
@@ -50,12 +53,13 @@ open class Renderer {
    - parameter store: the store of the application
    - returns: An instance of Renderer that manages rendering and store updates
   */
-  public init(rootDescription: AnyNodeDescription, store: AnyStore?) {
+  public init(rootDescription: AnyNodeDescription, store: AnyStore?, stateMockProvider: StateMockProvider? = nil) {
     self.store = store
+    self.stateMockProvider = stateMockProvider
 
     let unsubscribe = self.store?.addListener({ [unowned self] in
       self.storeDidChange()
-      })
+    })
 
     self.unsubscribe = unsubscribe
     self.rootNode = rootDescription.makeNode(renderer: self)

--- a/Katana/Core/Renderer/StateMockProvider.swift
+++ b/Katana/Core/Renderer/StateMockProvider.swift
@@ -8,16 +8,58 @@
 
 import Foundation
 
+/**
+ `StateMockProvider` is a class that can be used to mock the internal state of the descriptions
+ for testing purposes.
+ 
+ The basic idea is that the class encaspulates the possible mocks that are defined for a certain test case.
+ State mocks are defined in relation to a Description type and a filter. When the UI is rendered, and a
+ mock state provider is provided, Katana asks to the provider if there is a mocked state for the description
+ it is managing given the props the description has. If there is a mocked state, this state overrides the state.
+ 
+ It is important to note that this mechanism basically inhibits the `update` method in the descriptions.
+ 
+ - warning: it is important to remember that order matters. If two mocked state are available for the same context
+ (that is, description and props), the first will be used.
+ 
+ ### Usage
+ ```swift
+ let mock = StateMockProvider()
+ 
+ mock.mockState(ADescription.State(), for: ADescription.Type, passingFilter: { props in
+ // return true or false based on the props
+ })
+ 
+ let renderer = Renderer(rootDescription: description, store: store, stateMockProvider: mock)
+ ```
+*/
 public class StateMockProvider {
   
-  fileprivate var mocks: [String: [(filter: AnyFilterClosure, state: Any)]]
-  
+  /**
+   Closure that is used check whether a mocked state should be applied for a description
+   that has some properties
+   
+   - parameter props: the props of the description
+   - returns: whether the associated state should be applied or not
+  */
   public typealias FilterClosure<N: NodeDescription> = (_ props: N.PropsType) -> Bool
+  
+  /// The mocks that are defined
+  fileprivate var mocks: [String: [(filter: AnyFilterClosure, state: Any)]]
 
+  /// Creates a new mock provider
   public init() {
     self.mocks = [:]
   }
 
+  /**
+   Add a new mocked state
+   
+   - parameter mockedState: the state to mock
+   - parameter descriptionType: the description type to which the state will be applied to
+   - parameter filter: a closure that is used to check whether a state should be applied to a 
+                       specific description with props or not
+  */
   public func mockState<N: NodeDescription>(
     _ mockedState: N.StateType,
     for descriptionType: N.Type,
@@ -35,6 +77,13 @@ public class StateMockProvider {
     }
   }
   
+  /**
+   Retrieves a mocked state, if any, for a description with the given props
+   
+   - parameter descriptionType: the type of the description
+   - parameter props: the props of the description
+   - returns: the mocked state, if any
+  */
   func state<N: NodeDescription>(for descriptionType: N.Type, props: N.PropsType) -> N.StateType? {
     let descriptionStringName = String(reflecting: descriptionType.self)
     
@@ -51,14 +100,35 @@ public class StateMockProvider {
     
 }
 
+/// Struct used to type erase the FilterClosure
 fileprivate struct AnyFilterClosure {
+  
+  /// The filter closure
   private let filter: Any
   
-  init<N: NodeDescription>(_ description: N.Type, filter: @escaping StateMockProvider.FilterClosure<N>) {
+  /**
+   Creates a new type erasure for the closure
+   - parameter descriptionType: the type of the description for the filter
+   - parameter filter: the filter to type-erase
+
+   - warning: `descriptionType` shouldn't be necessary. Unfortunately the swift compiler fails to compile
+              because it is not able to infer the generic type without this parameter
+  */
+  init<N: NodeDescription>(_ descriptionType: N.Type, filter: @escaping StateMockProvider.FilterClosure<N>) {
     self.filter = filter
   }
-  
-  fileprivate func pass<N: NodeDescription>(_ description: N.Type, props: N.PropsType) -> Bool {
+
+  /**
+   Returns whether the erased filter passes with the given props. Note that if the filter is not
+   compatbile with the given description type, then the method will return false
+   - parameter descriptionType: the type of the description for the filter
+   - parameter props: the props that will be passed to the filter
+   - returns: whether the filter passes or not
+   
+   - warning: `descriptionType` shouldn't be necessary. Unfortunately the swift compiler fails to compile
+   because it is not able to infer the generic type without this parameter
+  */
+  fileprivate func pass<N: NodeDescription>(_ descriptionType: N.Type, props: N.PropsType) -> Bool {
     guard let filter = self.filter as? StateMockProvider.FilterClosure<N> else {
       return false
     }

--- a/Katana/Core/Renderer/StateMockProvider.swift
+++ b/Katana/Core/Renderer/StateMockProvider.swift
@@ -1,0 +1,68 @@
+//
+//  StateMockProvider.swift
+//  Katana
+//
+//  Created by Mauro Bolis on 02/04/2017.
+//  Copyright © 2017 Bending Spoons. All rights reserved.
+//
+
+import Foundation
+
+public class StateMockProvider {
+  
+  fileprivate var mocks: [String: [(filter: AnyFilterClosure, state: Any)]]
+  
+  public typealias FilterClosure<N: NodeDescription> = (_ props: N.PropsType) -> Bool
+
+  public init() {
+    self.mocks = [:]
+  }
+
+  public func mockState<N: NodeDescription>(
+    _ mockedState: N.StateType,
+    for descriptionType: N.Type,
+    passing filter: @escaping FilterClosure<N>) {
+    
+    let descriptionStringName = String(reflecting: descriptionType.self)
+    let anyFilter = AnyFilterClosure(descriptionType, filter: filter)
+    
+    if var descriptionMocks = self.mocks[descriptionStringName] {
+      descriptionMocks.append((filter: anyFilter, state: mockedState))
+      self.mocks[descriptionStringName] = descriptionMocks
+    
+    } else {
+      self.mocks[descriptionStringName] = [(filter: anyFilter, state: mockedState)]
+    }
+  }
+  
+  func state<N: NodeDescription>(for descriptionType: N.Type, props: N.PropsType) -> N.StateType? {
+    let descriptionStringName = String(reflecting: descriptionType.self)
+    
+    guard let possibleStates = self.mocks[descriptionStringName] else {
+      return nil
+    }
+    
+    return possibleStates
+      .first(where: { item -> Bool in
+        return item.filter.pass(descriptionType, props: props)
+      })
+      .flatMap { $0.state as? N.StateType }
+  }
+    
+}
+
+fileprivate struct AnyFilterClosure {
+  private let filter: Any
+  
+  init<N: NodeDescription>(_ description: N.Type, filter: @escaping StateMockProvider.FilterClosure<N>) {
+    self.filter = filter
+  }
+  
+  fileprivate func pass<N: NodeDescription>(_ description: N.Type, props: N.PropsType) -> Bool {
+    guard let filter = self.filter as? StateMockProvider.FilterClosure<N> else {
+      return false
+    }
+    
+    return filter(props)
+  }
+}

--- a/KatanaTests/Core/StateMockProviderTests.swift
+++ b/KatanaTests/Core/StateMockProviderTests.swift
@@ -1,0 +1,98 @@
+//
+//  StateMockProviderTests.swift
+//  Katana
+//
+//  Created by Mauro Bolis on 02/04/2017.
+//  Copyright © 2017 Bending Spoons. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Katana
+
+fileprivate struct CustomState: NodeDescriptionState {
+  let int: Int
+  
+  init(int: Int) {
+    self.int = int
+  }
+  
+  init() {
+    self.int = 99
+  }
+  
+  static func == (l: CustomState, r: CustomState) -> Bool {
+    return l.int == r.int
+  }
+}
+
+fileprivate struct CustomProps: NodeDescriptionProps {
+  var frame: CGRect = CGRect.zero
+  var key: String?
+  var alpha: CGFloat = 1.0
+  
+  var i: Int
+  
+  init(i: Int) {
+    self.i = i
+  }
+}
+
+fileprivate struct CustomDescription: NodeDescription {
+  typealias NativeView = TestView
+  typealias StateType = CustomState
+  typealias PropsType = CustomProps
+  
+  var props: PropsType
+  
+  init(props: PropsType) {
+    self.props = props
+  }
+  
+  public static func childrenDescriptions(props: PropsType,
+                                          state: StateType,
+                                          update: @escaping (StateType) -> (),
+                                          dispatch: @escaping StoreDispatch) -> [AnyNodeDescription] {
+    
+    return []
+  }
+}
+
+class StateMockProviderTests: XCTestCase {
+  func testBase() {
+    let provider = StateMockProvider()
+    
+    provider.mockState(CustomState(int: 101), for: CustomDescription.self, passing: {
+      return $0.i == 1000
+    })
+    
+    let state = provider.state(for: CustomDescription.self, props: CustomProps(i: 1000))
+    XCTAssertEqual(state, CustomState(int: 101))
+  }
+  
+  func testNotFound() {
+    let provider = StateMockProvider()
+    
+    provider.mockState(CustomState(int: 101), for: CustomDescription.self, passing: {
+      return $0.i == 90
+    })
+    
+    let state = provider.state(for: CustomDescription.self, props: CustomProps(i: 1000))
+    XCTAssertNil(state)
+  }
+  
+  func testTakeFirst() {
+    let provider = StateMockProvider()
+    
+    provider.mockState(CustomState(int: 100), for: CustomDescription.self, passing: {
+      return $0.i == 101
+    })
+    
+    provider.mockState(CustomState(int: 99), for: CustomDescription.self, passing: {
+      return $0.i == 101
+    })
+    
+    let state = provider.state(for: CustomDescription.self, props: CustomProps(i: 101))
+    XCTAssertEqual(state, CustomState(int: 100))
+  }
+}


### PR DESCRIPTION
**Why**
See #111    

**Changes**
Non breaking change
- added one more parameter to the `Renderer` init that is the state mock provider. 
- added `StateMockProvider` class

**Tasks**
* [X] Add relevant tests, if needed
* [X] Add documentation, if needed
* [X] Update README, if needed
* [X] Ensure that all the examples (as well as the demo) work properly