### PR TITLE
Refactor internal action management in store

### DIFF
--- a/Katana/Store/Store.swift
+++ b/Katana/Store/Store.swift
@@ -69,8 +69,7 @@ open class Store<StateType: State> {
   fileprivate var dependencies: SideEffectDependencyContainer!
 
   /**
-    The internal dispatch function. It combines all the operations that should be done when an action is dispatched.
-    The variable is explicitly unwrapped because of the init method
+    The internal dispatch function. It combines all the operations that should be done when an action is dispatched
   */
   fileprivate var dispatchFunction: StoreDispatch?
 


### PR DESCRIPTION
**Why**
We had several issues lately with the store.
In particular the very initial stages of the stores were problematic and lead to several issues
with middleware and dependencies conflicts. 

This PR refactors how actions are managed. Basically the idea is to offer a dispatch function that is always available and can immediately be used (e.g., middleware or dependencies can dispatch actions immediately). Internally, the store starts to manage these actions only when everything is ready (basically we have the middleware chain and the dependencies ready).

**Changes**
No public APIs are changed

**Tasks**
* [X] Add relevant tests, if needed
* [X] Add documentation, if needed
* [X] Update README, if needed
* [X] Ensure that all the examples (as well as the demo) work properly