### PR TITLE
Add Refs

### DIFF
--- a/Katana.xcodeproj/project.pbxproj
+++ b/Katana.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		A17EB5D41DD09E02009A5D8F /* AnimationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB5D31DD09E02009A5D8F /* AnimationUtils.swift */; };
 		A19385481E0D1F3C00F436D6 /* NodeDescriptionLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19385461E0D1F2100F436D6 /* NodeDescriptionLifecycleTests.swift */; };
 		A19385491E0D1F3E00F436D6 /* NodeDescriptionLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19385461E0D1F2100F436D6 /* NodeDescriptionLifecycleTests.swift */; };
+		A19CFBD71EA7826D00CBA236 /* Refs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19CFBD61EA7826D00CBA236 /* Refs.swift */; };
 		A1C9C1C31DD32D570067F8E0 /* InternalNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C9C1C21DD32D570067F8E0 /* InternalNode.swift */; };
 		A1C9C1C61DD337710067F8E0 /* ChildrenAnimationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C9C1C51DD337710067F8E0 /* ChildrenAnimationsTests.swift */; };
 		A1C9C1C81DD339D00067F8E0 /* AnimationUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C9C1C71DD339D00067F8E0 /* AnimationUtilsTests.swift */; };
@@ -395,6 +396,7 @@
 		A17EB5D11DD09B39009A5D8F /* ChildrenAnimations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChildrenAnimations.swift; sourceTree = "<group>"; };
 		A17EB5D31DD09E02009A5D8F /* AnimationUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationUtils.swift; sourceTree = "<group>"; };
 		A19385461E0D1F2100F436D6 /* NodeDescriptionLifecycleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NodeDescriptionLifecycleTests.swift; sourceTree = "<group>"; };
+		A19CFBD61EA7826D00CBA236 /* Refs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Refs.swift; sourceTree = "<group>"; };
 		A1C9C1C21DD32D570067F8E0 /* InternalNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InternalNode.swift; sourceTree = "<group>"; };
 		A1C9C1C51DD337710067F8E0 /* ChildrenAnimationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChildrenAnimationsTests.swift; sourceTree = "<group>"; };
 		A1C9C1C71DD339D00067F8E0 /* AnimationUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimationUtilsTests.swift; sourceTree = "<group>"; };
@@ -644,6 +646,7 @@
 		8133151B1D7B726000FBE210 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				A19CFBD51EA7824300CBA236 /* Refs */,
 				8133151E1D7B726000FBE210 /* Node */,
 				813315211D7B726000FBE210 /* NodeDescription */,
 				8133151C1D7B726000FBE210 /* Animations */,
@@ -943,6 +946,14 @@
 				A17AF9CB1DC9F5EF00F6076E /* View.swift */,
 			);
 			path = NodeDescriptions;
+			sourceTree = "<group>";
+		};
+		A19CFBD51EA7824300CBA236 /* Refs */ = {
+			isa = PBXGroup;
+			children = (
+				A19CFBD61EA7826D00CBA236 /* Refs.swift */,
+			);
+			path = Refs;
 			sourceTree = "<group>";
 		};
 		A1C9C1C41DD337300067F8E0 /* Animations */ = {
@@ -1510,6 +1521,7 @@
 				A1CA31511DC37DBF00982BE9 /* Action.swift in Sources */,
 				813315751D7B726000FBE210 /* EdgeInsets.swift in Sources */,
 				65BF2E9F1DE3635000441784 /* Typealiases.swift in Sources */,
+				A19CFBD71EA7826D00CBA236 /* Refs.swift in Sources */,
 				8133155D1D7B726000FBE210 /* Commons.swift in Sources */,
 				8133155F1D7B726000FBE210 /* NodeDescriptionWithChildren.swift in Sources */,
 				8133155E1D7B726000FBE210 /* NodeDescription.swift in Sources */,

--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -200,11 +200,16 @@ extension Node {
     }
     
     self.container?.update { view in
+      
+      let view = view as! Description.NativeView
+      
       Description.applyPropsToNativeView(props: self.description.props,
                                          state: self.state,
-                                         view: view as! Description.NativeView,
+                                         view: view,
                                          update: update,
                                          node: self)
+      
+      self.manageRef(for: self.description, view: view)
     }
     
     Description.didMount(props: self.description.props, dispatch: self.storeDispatch, update: update)
@@ -252,11 +257,16 @@ extension Node {
     
     let updateBlock = { () -> () in
       container.update { view in
+        
+        let view = view as! Description.NativeView 
+        
         Description.applyPropsToNativeView(props: self.description.props,
                                            state: self.state,
-                                           view: view as! Description.NativeView,
+                                           view: view,
                                            update: update,
                                            node: self)
+        
+        self.manageRef(for: self.description, view: view)
       }
     }
     
@@ -684,5 +694,23 @@ extension Node {
   public var renderer: Renderer? {
     guard self.myRenderer == nil else { return self.myRenderer! }
     return self.parent?.renderer
+  }
+}
+
+fileprivate extension Node {
+  
+  /**
+   Invokes, if needed, the ref callback for the given description using the given native view
+  */
+  fileprivate func manageRef(for description: Description, view: Description.NativeView) {
+    guard
+      let descriptionWithRef = self.description as? AnyNodeDescriptionWithRef,
+      let viewWithRef = view as? AnyPlatformNativeViewWithRef
+      
+      else {
+        return
+    }
+    
+    descriptionWithRef.anyRefCallback?(viewWithRef.anyRef)
   }
 }

--- a/Katana/Core/Node/Node.swift
+++ b/Katana/Core/Node/Node.swift
@@ -704,13 +704,13 @@ fileprivate extension Node {
   */
   fileprivate func manageRef(for description: Description, view: Description.NativeView) {
     guard
-      let descriptionWithRef = self.description as? AnyNodeDescriptionWithRef,
+      let propsWithRef = description.props as? AnyNodeDescriptionWithRefProps,
       let viewWithRef = view as? AnyPlatformNativeViewWithRef
       
       else {
         return
     }
     
-    descriptionWithRef.anyRefCallback?(viewWithRef.anyRef)
+    propsWithRef.anyRefCallback?(viewWithRef.anyRef)
   }
 }

--- a/Katana/Core/Refs/Refs.swift
+++ b/Katana/Core/Refs/Refs.swift
@@ -8,20 +8,38 @@
 
 import Foundation
 
+/// Closure used to provide the ref in node descriptions that implement the `NodeDescriptionWithRef` protocol
 public typealias RefCallbackClosure<Ref:  NativeViewRef> = (_ ref: Ref) -> Void
+
+/// Type erasure for `RefCallbackClosure`
 public typealias AnyRefCallbackClosure = (_ anyRef: Any) -> Void
 
+/// Type erasure for `NodeDescriptionWithRefProps`
 public protocol AnyNodeDescriptionWithRefProps: AnyNodeDescriptionProps {
+  
+  /// Type erasure for `refCallback` in `NodeDescriptionWithRefProps`
   var anyRefCallback: AnyRefCallbackClosure? { get }
 }
 
+/// Props type for node descriptions that implement the `NodeDescriptionWithRefProps` protocol
 public protocol NodeDescriptionWithRefProps: NodeDescriptionProps, AnyNodeDescriptionWithRefProps {
+  
+  /// The ref type that is associated with the node description
   associatedtype RefType: NativeViewRef
 
+  /**
+   A closure that is invoked when the ref is ready to be used. The exact moment when it
+   happens is an implementation detail and should not be leveraged to implement features or
+   behaviours. The idea is that the provided ref should be saved and used to implement imperative
+   behaviours
+  */
   var refCallback: RefCallbackClosure<RefType>? { get }
 }
 
+/// Default implementation of the `AnyNodeDescriptionWithRefProps` protocol
 public extension NodeDescriptionWithRefProps {
+  
+  /// The default implementation invokes `refCallback` with the correct type
   var anyRefCallback: AnyRefCallbackClosure? {
     guard let refClosure = self.refCallback else {
       return nil
@@ -29,7 +47,7 @@ public extension NodeDescriptionWithRefProps {
     
     return { refValue in
       // we want a crash here because it means there is something wrong
-      // in the element implementation. Fail silently here could lead to
+      // in the description implementation. Fail silently here could lead to
       // situations where is hard to debug the issue
       let typedRefValue = refValue as! RefType
       refClosure(typedRefValue)
@@ -37,30 +55,87 @@ public extension NodeDescriptionWithRefProps {
   }
 }
 
-
+/**
+ Node Descriptions can implement this protocol to provide a way to access to imperative behaviours.
+ 
+ There are two cases where this could be leveraged:
+ - updating the state/storage too often leads to performance issues. Refs could be used
+   to temporary skip the classic update cycle and improve the performances
+ 
+ - trigger imperative behaviours which would be hard/weird to implement with a declarative approach.
+   For instance, "dismiss/show keyboard" is a good example of imperative behaviour
+ 
+ In general refs, should be used as last resort. Declarative way is more appropriated in Katana and
+ in it is safer.
+*/
 public protocol NodeDescriptionWithRef: NodeDescription {
-  // add some constraints to the NativeView
+  
+  /// Extra constrains for the native view
   associatedtype NativeView: NativeViewWithRef
-    
+  
+  /// Extra constrains for the props
   associatedtype PropsType: NodeDescriptionWithRefProps
 }
 
+/// Type erasure for `NativeViewWithRef`
 public protocol AnyPlatformNativeViewWithRef {
+  
+  /// Type erasure for `ref` in `NativeViewWithRef`
   var anyRef: Any { get }
 }
 
+/**
+ Protocol for native views of descriptions that implement the `NodeDescriptionWithRef` protocol.
+ NativeViews should provide the ref values.
+*/
 public protocol NativeViewWithRef: PlatformNativeView, AnyPlatformNativeViewWithRef {
+  
+  /// The ref type that is returned
   associatedtype RefType: NativeViewRef
   
+  /// The ref instance of the native view
   var ref: RefType { get }
 }
 
+/// Implementation of the `AnyNativeViewWithRef` protocol
 public extension NativeViewWithRef {
+  
+  /// The default implementation returns `ref`
   var anyRef: Any {
     return self.ref
   }
 }
 
+/**
+ Protocol for refs.
+ 
+ A ref is nothing more that a proxy to the native view.
+ It is used for two reasons:
+  - limit the exposed properties/methods
+  - avoid retain cycles
+ 
+ The second reason also requires a special attention during the implementation.
+ 
+ In particular, the idea is that the ref should contain a weak reference to the native view.
+ The init should be therefore implemented in the following way:
+ 
+ ```swift
+ init(nativeView: NativeTextField) {
+  weak var s: NativeViewType? = nativeView
+  self.nativeView = s
+ }
+ ```
+ 
+ where `nativeView` is a weak variable
+ 
+ ```swift
+ private weak var nativeView: NativeViewType?
+ ```
+ 
+ Failing in implement the ref in the proper way could lead to wrong behaviours, memory leaks and so on.
+ 
+ - seeAlso: `NodeDescriptionWithRef`
+*/
 public protocol NativeViewRef {
   associatedtype NativeViewType: PlatformNativeView
   

--- a/Katana/Core/Refs/Refs.swift
+++ b/Katana/Core/Refs/Refs.swift
@@ -1,0 +1,64 @@
+//
+//  Refs.swift
+//  Katana
+//
+//  Created by Mauro Bolis on 19/04/2017.
+//  Copyright © 2017 Bending Spoons. All rights reserved.
+//
+
+import Foundation
+
+public typealias RefCallbackClosure<Ref:  NativeViewRef> = (_ ref: Ref) -> Void
+public typealias AnyRefCallbackClosure = (_ anyRef: Any) -> Void
+
+public protocol AnyNodeDescriptionWithRef: AnyNodeDescription {
+  var anyRefCallback: AnyRefCallbackClosure? { get }
+}
+
+public protocol NodeDescriptionWithRef: NodeDescription, AnyNodeDescriptionWithRef {
+
+  // add some constraints to the NativeView
+  associatedtype NativeView: PlatformNativeViewWithRef
+  
+  var refCallback: RefCallbackClosure<NativeView.RefType>? { get }
+}
+
+public extension NodeDescriptionWithRef {
+  var anyRefProvider: AnyRefCallbackClosure? {
+    guard let refClosure = self.refCallback else {
+      return nil
+    }
+    
+    return { refValue in
+      // we want a crash here because it means there is something wrong
+      // in the element implementation. Fail silently here could lead to
+      // situations where is hard to debug the issue
+      let typedRefValue = refValue as! NativeView.RefType
+      refClosure(typedRefValue)
+    }
+  }
+}
+
+public protocol AnyPlatformNativeViewWithRef {
+  var anyRef: Any { get }
+}
+
+public protocol PlatformNativeViewWithRef: PlatformNativeView {
+  associatedtype RefType: NativeViewRef
+  
+  var ref: RefType { get }
+}
+
+public extension PlatformNativeViewWithRef {
+  var anyRef: Any {
+    return self.ref
+  }
+}
+
+public protocol NativeViewRef {
+  associatedtype NativeView: PlatformNativeView
+  
+  init(nativeView: NativeView)
+  
+  var isValid: Bool { get }
+}

--- a/KatanaElements/iOS/Table/NativeTable.swift
+++ b/KatanaElements/iOS/Table/NativeTable.swift
@@ -90,3 +90,30 @@ extension NativeTable: UITableViewDelegate {
     cell.didTap(atIndexPath: indexPath)
   }
 }
+
+extension NativeTable: NativeViewWithRef {
+  public typealias RefType = TableRef
+  
+  public var ref: RefType {
+    return TableRef(nativeView: self)
+  }
+}
+
+public struct TableRef: NativeViewRef {
+  public typealias NativeViewType = NativeTable
+
+  private weak var nativeView: NativeViewType?
+  
+  public var isValid: Bool {
+    return self.nativeView != nil
+  }
+  
+  public init(nativeView: NativeViewType) {
+    weak var s: NativeViewType? = nativeView
+    self.nativeView = s
+  }
+  
+  public func scroll(at indexPath: IndexPath, at position: UITableViewScrollPosition, animated: Bool) {
+    self.nativeView?.scrollToRow(at: indexPath, at: position, animated: animated)
+  }
+}

--- a/KatanaElements/iOS/Table/Table.swift
+++ b/KatanaElements/iOS/Table/Table.swift
@@ -11,7 +11,7 @@ import UIKit
 import Katana
 
 public extension Table {
-  public struct Props: NodeDescriptionProps, Buildable {
+  public struct Props: NodeDescriptionProps, NodeDescriptionWithRefProps, Buildable {
     public var frame = CGRect.zero
     public var key: String?
     public var alpha: CGFloat = 1.0
@@ -22,6 +22,7 @@ public extension Table {
     public var borderWidth: CGFloat = 0.0
     public var borderColor = UIColor.clear
     public var clipsToBounds = true
+    public var refCallback: RefCallbackClosure<TableRef>?
 
     public init() {}
 
@@ -40,11 +41,11 @@ public extension Table {
   }
 }
 
-public struct Table: NodeDescription {
+public struct Table: NodeDescription, NodeDescriptionWithRef {
   public typealias NativeView = NativeTable
 
   public var props: Props
-
+  
   public init(props: Props) {
     self.props = props
   }


### PR DESCRIPTION
**Why**
Sometimes declarative is not enough. This PR adds proper protocols to introduce a little bit of imperative APIs in the Katana NodeDescriptions.

See also #121 for more information

**Changes**
- Add `NodeDescriptionWithRef` protocol (and relative protocols)

No breaking changes

**Tasks**
* [X] Add relevant tests, if needed
* [X] Add documentation, if needed
* [X] Update README, if needed
* [X] Ensure that all the examples (as well as the demo) work properly