### PR TITLE
Remove performWithoutAnimation

### DIFF
--- a/Katana/iOS/UIView+PlatformNativeView.swift
+++ b/Katana/iOS/UIView+PlatformNativeView.swift
@@ -157,7 +157,7 @@ extension UIView: PlatformNativeView {
 
     switch type {
     case .none:
-      UIView.performWithoutAnimation(block)
+      block()
       completion?()
 
     case let .linear(duration):


### PR DESCRIPTION
**Why**
UIView performWithoutAnimation is preventing the animation to all the children elements like for instance the insertion/deletion animations in a Grid when you do performBatchUpdates.
Removing performWithoutAnimation *seems* to have no side effects while enabling those animations.
