### PR TITLE
Fix Connect Wrong Behaviour

### DIFF
--- a/Katana/Core/Renderer/Renderer.swift
+++ b/Katana/Core/Renderer/Renderer.swift
@@ -121,14 +121,15 @@ open class Renderer {
       childrenTable[ObjectIdentifier(node)] = node
     }
 
-    if node.anyDescription is AnyConnectedNodeDescription {
+    let isNodeAlreadyUpdated = self.currentUpdateCycleUpdatedNodes.contains(ObjectIdentifier(node))
+    
+    if node.anyDescription is AnyConnectedNodeDescription && !isNodeAlreadyUpdated {
       // ok the description is connected to the node, let's trigger an update
       node.update(with: node.anyDescription, animation: .none, completion: nil)
     }
 
     node.children
       .flatMap { childrenTable[ObjectIdentifier($0)] }
-      .filter { !self.currentUpdateCycleUpdatedNodes.contains(ObjectIdentifier($0)) }
       .forEach { self.explore($0) }
 
     node.managedChildren.forEach { self.explore($0) }


### PR DESCRIPTION
This PR fixes an edge cases during the update of the UI after a state change.

The edge case is the following.

Suppose we have the following UI
A
..|_C1
......|_C2
..........|_C3

C1 is connected and its props changes.
This trigger an update of C2, which is connected too.
But C2's props don't change.

With the previous code, C2 was ignored in the explore because the update was already invoked. That would cause that also C3 (which is connected) is skipped in the explore cycle.
C3 though was never updated (because C2 props haven't changed) despite the fact that it is connected, and therefore it could change