### PR TITLE
Add warning

### DIFF
--- a/Katana/Core/NodeDescription/NodeDescription.swift
+++ b/Katana/Core/NodeDescription/NodeDescription.swift
@@ -86,6 +86,7 @@ public extension NodeDescriptionProps {
    - returns: always false
   */
   static func == (l: Self, r: Self) -> Bool {
+    print("Warning: default `==` implementation used for (\(String(reflecting: self.self))))")
     return false
   }
 }


### PR DESCRIPTION
Add warning when `Props`’ fallback on the default Equatable implementation.
Currently, developers easily forget to implement proper `Equatables` to the Props in order to optimise performances. This warning attempts to address this issue.