### PR TITLE
Add store initializer

### DIFF
--- a/Katana.xcodeproj/project.pbxproj
+++ b/Katana.xcodeproj/project.pbxproj
@@ -6,303 +6,321 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00EB19DB70DF3B5B661654F9 /* CounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EC3065F3FEA2E1746353C21 /* CounterView.swift */; };
-		05F0D520A989F2E387338BF6 /* MiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133BA69FF37651DD55E6CDEB /* MiddlewareTests.swift */; };
-		0AE44C78607D639F74CB5DA0 /* SideEffectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB413ACBD4D6FC4194D86D29 /* SideEffectTests.swift */; };
-		2071A57C771B42E563B28555 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 69ADB1B2D4814ED470A2D64D /* LaunchScreen.storyboard */; };
-		23A87CFD92C3F6431BD4DDEA /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522FD61ACE69D3ED63DE9A4E /* ActionTests.swift */; };
-		24E7A11B84B5850A3272BC7B /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DEF11AE84FD98C30581F49B /* DependencyContainer.swift */; };
-		2A6FD0BC8DEEA2A64BB8D1D7 /* CounterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0217831E86DC6138833731FA /* CounterViewController.swift */; };
-		2AB8A3A90933E45C37EF614C /* Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E182E698B138B8632F95EA28 /* Actions.swift */; };
-		3169E285F0E9CE120542895A /* StoreTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = A612BDC7860DF41EE27BFF34 /* StoreTypealiases.swift */; };
-		3AD4A4AB0B6B9828CD24D19A /* ActionLinkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CAD2CE05F5E8FBFEACEC98 /* ActionLinkerTests.swift */; };
-		3D361175E4AD6D0DA64149FB /* LinkeableAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B982A85FCC398666A7105C32 /* LinkeableAction.swift */; };
-		528A5A20C8782B6D24F433B5 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C41C3D2475D76CECEADFA6B /* AppState.swift */; };
-		58ED88F2B7CCF277F02C68C2 /* ActionWithSideEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3584E7ABBCD36F8B008EA8B0 /* ActionWithSideEffect.swift */; };
-		666C11C43DF701DF5617545F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5D6EF710A5062D23E1361FE /* Foundation.framework */; };
-		6AD0A50E29C0BA163ED32E0D /* Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0347219B88D6B607178B96 /* Actions.swift */; };
-		767E331261481CBFB4DF3A6C /* AppDependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A33BC79854DEAA76966CF03 /* AppDependenciesContainer.swift */; };
-		8D31B681605C41BDEC8671D7 /* AsyncAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424E040CA2A26F3AAB57DAAB /* AsyncAction.swift */; };
-		AB9824029042DCC630998A10 /* Katana.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9335F2EB9A93914CA5FED149 /* Katana.framework */; };
-		B8005D5C9C8DEECCC2332C3F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6DA00DB69DF353F3A8674A8 /* UIKit.framework */; };
-		B9803C960217691B5EA10E43 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE672C1040AEB646A248DD6 /* Action.swift */; };
-		C056AD28CAE48B67A37C4BB0 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A1196FFB31D3F9E8DC5A92 /* Store.swift */; };
-		CAE0BED835FBA4F3164FE673 /* SideEffectDependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D6C67CEA65844EA8E678028 /* SideEffectDependencyContainer.swift */; };
-		CB35F709496B20057D0171AD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECE6CF89A317655863983BB /* AppDelegate.swift */; };
-		CB482691321B662D92CE88E2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5D6EF710A5062D23E1361FE /* Foundation.framework */; };
-		D097C942E7060D496F9CDE1E /* Katana.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9335F2EB9A93914CA5FED149 /* Katana.framework */; };
-		D118ACA3C8E027E95AF1CB36 /* UIColor+Demo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5255C8E248A101EF39C6F1DC /* UIColor+Demo.swift */; };
-		DB667B7CF283D0B263EB2FA1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6DA00DB69DF353F3A8674A8 /* UIKit.framework */; };
-		DD7E492DB40D086D256CE40F /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6DA00DB69DF353F3A8674A8 /* UIKit.framework */; };
-		E3F40F56CCCD4F628E9A5E65 /* Katana.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F81960D226EA7E800460E69 /* Katana.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E3F890459C304230682A39EA /* AsyncActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE2CF179B34DB62245A71E7 /* AsyncActionTests.swift */; };
-		E76F9A02D4B219C426EA5FC2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5D6EF710A5062D23E1361FE /* Foundation.framework */; };
-		E8A7D327450E5408F3567B77 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697C39729F85BB7216D0D994 /* StoreTests.swift */; };
-		E8CDCADFBDC57E370BFA47B9 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = C935D65E7EB4E2877098633C /* State.swift */; };
-		E91901F91C0347CC1CB5217B /* ActionLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 613EB44C65B6FAA511EC461C /* ActionLinks.swift */; };
-		F635D03DF471A031427F05D1 /* States.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD4AD42FA3FD301B2B85BAA /* States.swift */; };
-		F6A0A985A17EBBD6902C8178 /* ActionLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CCCE0457B56D63C06778A9 /* ActionLinker.swift */; };
+		0F03F068C5707C48420E3A9B /* ActionLinkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B0974E905FA04CAA8A08501 /* ActionLinkerTests.swift */; };
+		0F0BB9C7D353843E25AE69C8 /* Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6128DF0A9C17FDBB9F23CD8 /* Actions.swift */; };
+		11F033D469440A5F496D3DB5 /* CounterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FDDB9A3397E159A9594101 /* CounterViewController.swift */; };
+		1789AB64F62B2DCF72B23714 /* StoreTypealiases.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE4DEC57EB7096DF649A2088 /* StoreTypealiases.swift */; };
+		17CB2EF8D7FFD65009E53331 /* AsyncAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EEEC8C752531D111DF5464 /* AsyncAction.swift */; };
+		31131ABCBB5DB2E855175752 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C968701DA467FE7975B6BB6 /* Foundation.framework */; };
+		36B04AEE8C4024997C5C73FE /* ActionLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0FF0DB77BF871A3455A007 /* ActionLinker.swift */; };
+		434FFA556E68C7EF19C42873 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 324D8956834FF36991E20799 /* LaunchScreen.storyboard */; };
+		48A4885AB2A541E461E282AA /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B7DEA54870FFD6201CF7EB /* DependencyContainer.swift */; };
+		4D1475F65A102B36B7B7713B /* ActionWithSideEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864B4A5F02AC90EE3BFD265D /* ActionWithSideEffect.swift */; };
+		52CBC931F0CFB8505A539628 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B231B01440E1EB17FB7B1A2 /* UIKit.framework */; };
+		562A1A3EC75BA38B5A5D8D34 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C968701DA467FE7975B6BB6 /* Foundation.framework */; };
+		6076D1E3340CF3C5C401B395 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFEBF0EFB83F80C12B6FB94 /* AppDelegate.swift */; };
+		65BFB24E357D33FB58490BF4 /* SideEffectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D317D8705BD1D45086923B7A /* SideEffectTests.swift */; };
+		6C84CAAEE1ACD865C28BE9BC /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B231B01440E1EB17FB7B1A2 /* UIKit.framework */; };
+		80AB3E91667CC034B3336FD7 /* ActionLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD2E5DFCD540AFFF6DC5ABD /* ActionLinks.swift */; };
+		8BB909344DCABB8A1E493544 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEAC904C2B187E39817AA3F8 /* Store.swift */; };
+		8D3CAE5D08970AD3BC970EA7 /* MiddlewareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C2CCBE493D877533D458B4 /* MiddlewareTests.swift */; };
+		9108C21F43B3BCB1B2ED7BC4 /* AsyncActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05FBAE0C5568412CAFA463 /* AsyncActionTests.swift */; };
+		9B3BC440D0BF5B7D9786BAB5 /* Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B5136BB228DA0D1EAF9347 /* Actions.swift */; };
+		A0184ECB3BBF8C4FDC7126D1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C968701DA467FE7975B6BB6 /* Foundation.framework */; };
+		BE2C2232926B6EC0745A19F4 /* Katana.h in Headers */ = {isa = PBXBuildFile; fileRef = B1C122C76A6DE3F4F01E039E /* Katana.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C5F0911240794F536243DBEF /* Katana.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 636EEC3252E8A6CB694674BE /* Katana.framework */; };
+		C715E754BF65E9067CB0ED36 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727156680F2E89F697986EC3 /* ActionTests.swift */; };
+		C8BD88BB2D5643BC2CE58A9A /* UIColor+Demo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A97E21BCF1F91536A6D73E7 /* UIColor+Demo.swift */; };
+		CA2DED2956D29033611512F3 /* Katana.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 636EEC3252E8A6CB694674BE /* Katana.framework */; };
+		CE833C2BF2E9BC9CB1D2AEF0 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C001D947DB3EF35D7C3E55 /* StoreTests.swift */; };
+		CF1772694E2C6C1D7C64CD1D /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55D4329060E5566C5C511D3 /* State.swift */; };
+		CF6EA40CA61E19BCDA3AF191 /* LinkeableAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D953DA16E2F6772BA4E875A /* LinkeableAction.swift */; };
+		CFE0E8491D90F2DA74C60149 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B231B01440E1EB17FB7B1A2 /* UIKit.framework */; };
+		D37A0AD9367388AA828B0CA5 /* CounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DD68562AB97BBA33110002 /* CounterView.swift */; };
+		D6F9577C75B3BEC7E830B0BD /* States.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E5B609F41A340E96571FC3 /* States.swift */; };
+		D769081A46AEA0354AB3F92B /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F838BF29F93F3031EAEEFA6F /* AppState.swift */; };
+		EC5B0FB8F7AC440E857492E6 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F7E742842D432C653DAB07 /* Action.swift */; };
+		F5A8BA27244200B1E365A368 /* AppDependenciesContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3227752FD9A9395EE8413C /* AppDependenciesContainer.swift */; };
+		FAE0D8B11A23939284681D3D /* SideEffectDependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED7C7CC4753A0DF3C219D63 /* SideEffectDependencyContainer.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		3562D2CA25FEB2A8020E4154 /* PBXContainerItemProxy */ = {
+		43F7615D50ABCD54D146FF96 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BB5AA88D8AB3B8C68652A7B6 /* Project object */;
+			containerPortal = DEC633B4258B2EDC10FF3657 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 42B7BB264BF676AF4E06588C;
+			remoteGlobalIDString = 64F0E5CC681AAB7322579B9F;
 			remoteInfo = Katana;
 		};
-		A56F7DBEEA793475BB4E7899 /* PBXContainerItemProxy */ = {
+		76F8008FA19B56CCF2D38281 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BB5AA88D8AB3B8C68652A7B6 /* Project object */;
+			containerPortal = DEC633B4258B2EDC10FF3657 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 42B7BB264BF676AF4E06588C;
+			remoteGlobalIDString = 64F0E5CC681AAB7322579B9F;
 			remoteInfo = Katana;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0217831E86DC6138833731FA /* CounterViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CounterViewController.swift; sourceTree = "<group>"; };
-		0DEF11AE84FD98C30581F49B /* DependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependencyContainer.swift; sourceTree = "<group>"; };
-		0F81960D226EA7E800460E69 /* Katana.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Katana.h; sourceTree = "<group>"; };
-		133BA69FF37651DD55E6CDEB /* MiddlewareTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MiddlewareTests.swift; sourceTree = "<group>"; };
-		1AE672C1040AEB646A248DD6 /* Action.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
-		2BD4AD42FA3FD301B2B85BAA /* States.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = States.swift; sourceTree = "<group>"; };
-		2DF25517DA1C72FF42676516 /* KatanaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KatanaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		2EC3065F3FEA2E1746353C21 /* CounterView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CounterView.swift; sourceTree = "<group>"; };
-		3584E7ABBCD36F8B008EA8B0 /* ActionWithSideEffect.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionWithSideEffect.swift; sourceTree = "<group>"; };
-		3A33BC79854DEAA76966CF03 /* AppDependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDependenciesContainer.swift; sourceTree = "<group>"; };
-		424E040CA2A26F3AAB57DAAB /* AsyncAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AsyncAction.swift; sourceTree = "<group>"; };
-		522FD61ACE69D3ED63DE9A4E /* ActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionTests.swift; sourceTree = "<group>"; };
-		5255C8E248A101EF39C6F1DC /* UIColor+Demo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIColor+Demo.swift"; sourceTree = "<group>"; };
-		5CE2CF179B34DB62245A71E7 /* AsyncActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AsyncActionTests.swift; sourceTree = "<group>"; };
-		613EB44C65B6FAA511EC461C /* ActionLinks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionLinks.swift; sourceTree = "<group>"; };
-		697C39729F85BB7216D0D994 /* StoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StoreTests.swift; sourceTree = "<group>"; };
-		69ADB1B2D4814ED470A2D64D /* LaunchScreen.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
-		7C41C3D2475D76CECEADFA6B /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
-		7E0347219B88D6B607178B96 /* Actions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Actions.swift; sourceTree = "<group>"; };
-		85CAD2CE05F5E8FBFEACEC98 /* ActionLinkerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionLinkerTests.swift; sourceTree = "<group>"; };
-		9335F2EB9A93914CA5FED149 /* Katana.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Katana.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		96CCCE0457B56D63C06778A9 /* ActionLinker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionLinker.swift; sourceTree = "<group>"; };
-		9D6C67CEA65844EA8E678028 /* SideEffectDependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideEffectDependencyContainer.swift; sourceTree = "<group>"; };
-		A612BDC7860DF41EE27BFF34 /* StoreTypealiases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StoreTypealiases.swift; sourceTree = "<group>"; };
-		AC908790248DA785CE86881E /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		B6DA00DB69DF353F3A8674A8 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		B982A85FCC398666A7105C32 /* LinkeableAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LinkeableAction.swift; sourceTree = "<group>"; };
-		BB413ACBD4D6FC4194D86D29 /* SideEffectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideEffectTests.swift; sourceTree = "<group>"; };
-		C935D65E7EB4E2877098633C /* State.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
-		D5A1196FFB31D3F9E8DC5A92 /* Store.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
-		D5D6EF710A5062D23E1361FE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		E182E698B138B8632F95EA28 /* Actions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Actions.swift; sourceTree = "<group>"; };
-		EECE6CF89A317655863983BB /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		06F7E742842D432C653DAB07 /* Action.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
+		0ED7C7CC4753A0DF3C219D63 /* SideEffectDependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideEffectDependencyContainer.swift; sourceTree = "<group>"; };
+		26DD68562AB97BBA33110002 /* CounterView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CounterView.swift; sourceTree = "<group>"; };
+		2C968701DA467FE7975B6BB6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		324D8956834FF36991E20799 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		37B5136BB228DA0D1EAF9347 /* Actions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Actions.swift; sourceTree = "<group>"; };
+		3B0974E905FA04CAA8A08501 /* ActionLinkerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionLinkerTests.swift; sourceTree = "<group>"; };
+		48EEEC8C752531D111DF5464 /* AsyncAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AsyncAction.swift; sourceTree = "<group>"; };
+		532F9A15268446A1A717F376 /* KatanaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KatanaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		59E5B609F41A340E96571FC3 /* States.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = States.swift; sourceTree = "<group>"; };
+		5B231B01440E1EB17FB7B1A2 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		5FD2E5DFCD540AFFF6DC5ABD /* ActionLinks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionLinks.swift; sourceTree = "<group>"; };
+		636EEC3252E8A6CB694674BE /* Katana.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Katana.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6AFEBF0EFB83F80C12B6FB94 /* AppDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		727156680F2E89F697986EC3 /* ActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionTests.swift; sourceTree = "<group>"; };
+		7B0FF0DB77BF871A3455A007 /* ActionLinker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionLinker.swift; sourceTree = "<group>"; };
+		864B4A5F02AC90EE3BFD265D /* ActionWithSideEffect.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActionWithSideEffect.swift; sourceTree = "<group>"; };
+		8A97E21BCF1F91536A6D73E7 /* UIColor+Demo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIColor+Demo.swift"; sourceTree = "<group>"; };
+		8D953DA16E2F6772BA4E875A /* LinkeableAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LinkeableAction.swift; sourceTree = "<group>"; };
+		99FDDB9A3397E159A9594101 /* CounterViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CounterViewController.swift; sourceTree = "<group>"; };
+		A0B7DEA54870FFD6201CF7EB /* DependencyContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependencyContainer.swift; sourceTree = "<group>"; };
+		A6128DF0A9C17FDBB9F23CD8 /* Actions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Actions.swift; sourceTree = "<group>"; };
+		AA05FBAE0C5568412CAFA463 /* AsyncActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AsyncActionTests.swift; sourceTree = "<group>"; };
+		AD3227752FD9A9395EE8413C /* AppDependenciesContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppDependenciesContainer.swift; sourceTree = "<group>"; };
+		B1C122C76A6DE3F4F01E039E /* Katana.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = Katana.h; sourceTree = "<group>"; };
+		B55D4329060E5566C5C511D3 /* State.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
+		BD309159693A6220D827E358 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE4DEC57EB7096DF649A2088 /* StoreTypealiases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StoreTypealiases.swift; sourceTree = "<group>"; };
+		C4C001D947DB3EF35D7C3E55 /* StoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StoreTests.swift; sourceTree = "<group>"; };
+		D317D8705BD1D45086923B7A /* SideEffectTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SideEffectTests.swift; sourceTree = "<group>"; };
+		DEAC904C2B187E39817AA3F8 /* Store.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
+		E1C2CCBE493D877533D458B4 /* MiddlewareTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MiddlewareTests.swift; sourceTree = "<group>"; };
+		F838BF29F93F3031EAEEFA6F /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		16B3825B2EE2E4CD549EB01D /* Frameworks */ = {
+		10F9B68D00ACBE229E4F4C83 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				666C11C43DF701DF5617545F /* Foundation.framework in Frameworks */,
-				B8005D5C9C8DEECCC2332C3F /* UIKit.framework in Frameworks */,
+				562A1A3EC75BA38B5A5D8D34 /* Foundation.framework in Frameworks */,
+				52CBC931F0CFB8505A539628 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		898649A1F991AD1767C3DAEF /* Frameworks */ = {
+		DA0A9632A63BC84EE48C8209 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CB482691321B662D92CE88E2 /* Foundation.framework in Frameworks */,
-				DB667B7CF283D0B263EB2FA1 /* UIKit.framework in Frameworks */,
-				AB9824029042DCC630998A10 /* Katana.framework in Frameworks */,
+				CA2DED2956D29033611512F3 /* Katana.framework in Frameworks */,
+				A0184ECB3BBF8C4FDC7126D1 /* Foundation.framework in Frameworks */,
+				6C84CAAEE1ACD865C28BE9BC /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8B69045F55CA9F5A0A3F79D8 /* Frameworks */ = {
+		E402E0812A9E329AE4F99529 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E76F9A02D4B219C426EA5FC2 /* Foundation.framework in Frameworks */,
-				DD7E492DB40D086D256CE40F /* UIKit.framework in Frameworks */,
-				D097C942E7060D496F9CDE1E /* Katana.framework in Frameworks */,
+				C5F0911240794F536243DBEF /* Katana.framework in Frameworks */,
+				31131ABCBB5DB2E855175752 /* Foundation.framework in Frameworks */,
+				CFE0E8491D90F2DA74C60149 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		22A227561DA2268367837C56 /* Middleware */ = {
+		0FAC3E0D8C2651C3C9C622C6 = {
 			isa = PBXGroup;
 			children = (
-				9A98B7646B4C888EB508E179 /* ActionLinker */,
+				87E49D5076F05F37DEDEFB1A /* Products */,
+				9BC6CCBB49DF873057FB583E /* Frameworks */,
+				EB5D218DE7E469F590BF5DE5 /* KatanaTests */,
+				6A534062C2A5A1C279EE3157 /* Katana */,
+				362A5585715375D0CC4F13E7 /* Demo */,
 			);
-			name = Middleware;
-			path = Middleware;
 			sourceTree = "<group>";
 		};
-		40032F61E85025482496B4C7 /* Products */ = {
+		362A5585715375D0CC4F13E7 /* Demo */ = {
 			isa = PBXGroup;
 			children = (
-				2DF25517DA1C72FF42676516 /* KatanaTests.xctest */,
-				9335F2EB9A93914CA5FED149 /* Katana.framework */,
-				AC908790248DA785CE86881E /* Demo.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		4F51F8E107F4960F90F24313 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				522FD61ACE69D3ED63DE9A4E /* ActionTests.swift */,
-				5CE2CF179B34DB62245A71E7 /* AsyncActionTests.swift */,
-				133BA69FF37651DD55E6CDEB /* MiddlewareTests.swift */,
-				BB413ACBD4D6FC4194D86D29 /* SideEffectTests.swift */,
-				85CAD2CE05F5E8FBFEACEC98 /* ActionLinkerTests.swift */,
-				697C39729F85BB7216D0D994 /* StoreTests.swift */,
-			);
-			name = Core;
-			path = Core;
-			sourceTree = "<group>";
-		};
-		57FE94B406DF079AC70D391F /* Katana */ = {
-			isa = PBXGroup;
-			children = (
-				22A227561DA2268367837C56 /* Middleware */,
-				C935D65E7EB4E2877098633C /* State.swift */,
-				A612BDC7860DF41EE27BFF34 /* StoreTypealiases.swift */,
-				424E040CA2A26F3AAB57DAAB /* AsyncAction.swift */,
-				D5A1196FFB31D3F9E8DC5A92 /* Store.swift */,
-				9D6C67CEA65844EA8E678028 /* SideEffectDependencyContainer.swift */,
-				1AE672C1040AEB646A248DD6 /* Action.swift */,
-				3584E7ABBCD36F8B008EA8B0 /* ActionWithSideEffect.swift */,
-				0F81960D226EA7E800460E69 /* Katana.h */,
-			);
-			name = Katana;
-			path = Katana;
-			sourceTree = "<group>";
-		};
-		694C5D21754ED9C80C777C08 /* KatanaTests */ = {
-			isa = PBXGroup;
-			children = (
-				4F51F8E107F4960F90F24313 /* Core */,
-				EA53D7C72170CC5C501A1CA4 /* Models */,
-			);
-			name = KatanaTests;
-			path = KatanaTests;
-			sourceTree = "<group>";
-		};
-		9A98B7646B4C888EB508E179 /* ActionLinker */ = {
-			isa = PBXGroup;
-			children = (
-				B982A85FCC398666A7105C32 /* LinkeableAction.swift */,
-				96CCCE0457B56D63C06778A9 /* ActionLinker.swift */,
-				613EB44C65B6FAA511EC461C /* ActionLinks.swift */,
-			);
-			name = ActionLinker;
-			path = ActionLinker;
-			sourceTree = "<group>";
-		};
-		A091A86240CB4DA7CFE83F74 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				D5D6EF710A5062D23E1361FE /* Foundation.framework */,
-				B6DA00DB69DF353F3A8674A8 /* UIKit.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		B86EB21C007A7483CC7934D0 /* Demo */ = {
-			isa = PBXGroup;
-			children = (
-				E3DA3BAE32BA4E3869653EDD /* Logic */,
-				5255C8E248A101EF39C6F1DC /* UIColor+Demo.swift */,
-				0217831E86DC6138833731FA /* CounterViewController.swift */,
-				2EC3065F3FEA2E1746353C21 /* CounterView.swift */,
-				EECE6CF89A317655863983BB /* AppDelegate.swift */,
-				69ADB1B2D4814ED470A2D64D /* LaunchScreen.storyboard */,
+				E0F4B4E4DFEB760E5CC32846 /* Logic */,
+				8A97E21BCF1F91536A6D73E7 /* UIColor+Demo.swift */,
+				99FDDB9A3397E159A9594101 /* CounterViewController.swift */,
+				26DD68562AB97BBA33110002 /* CounterView.swift */,
+				6AFEBF0EFB83F80C12B6FB94 /* AppDelegate.swift */,
+				324D8956834FF36991E20799 /* LaunchScreen.storyboard */,
 			);
 			name = Demo;
 			path = Demo;
 			sourceTree = "<group>";
 		};
-		D8A637B8EF8D8A835A214B14 /* Frameworks */ = {
+		41293D8E23BA15526BA2E0AF /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				A091A86240CB4DA7CFE83F74 /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		E3DA3BAE32BA4E3869653EDD /* Logic */ = {
-			isa = PBXGroup;
-			children = (
-				7C41C3D2475D76CECEADFA6B /* AppState.swift */,
-				3A33BC79854DEAA76966CF03 /* AppDependenciesContainer.swift */,
-				E182E698B138B8632F95EA28 /* Actions.swift */,
-			);
-			name = Logic;
-			path = Logic;
-			sourceTree = "<group>";
-		};
-		EA53D7C72170CC5C501A1CA4 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				0DEF11AE84FD98C30581F49B /* DependencyContainer.swift */,
-				2BD4AD42FA3FD301B2B85BAA /* States.swift */,
-				7E0347219B88D6B607178B96 /* Actions.swift */,
+				A0B7DEA54870FFD6201CF7EB /* DependencyContainer.swift */,
+				59E5B609F41A340E96571FC3 /* States.swift */,
+				37B5136BB228DA0D1EAF9347 /* Actions.swift */,
 			);
 			name = Models;
 			path = Models;
 			sourceTree = "<group>";
 		};
-		EAFA2A6432679B90EA11021E = {
+		45D916B55035B3B103454C0D /* ActionLinker */ = {
 			isa = PBXGroup;
 			children = (
-				40032F61E85025482496B4C7 /* Products */,
-				D8A637B8EF8D8A835A214B14 /* Frameworks */,
-				694C5D21754ED9C80C777C08 /* KatanaTests */,
-				57FE94B406DF079AC70D391F /* Katana */,
-				B86EB21C007A7483CC7934D0 /* Demo */,
+				8D953DA16E2F6772BA4E875A /* LinkeableAction.swift */,
+				7B0FF0DB77BF871A3455A007 /* ActionLinker.swift */,
+				5FD2E5DFCD540AFFF6DC5ABD /* ActionLinks.swift */,
 			);
+			name = ActionLinker;
+			path = ActionLinker;
+			sourceTree = "<group>";
+		};
+		53DF333701C3230CCE783ECC /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				727156680F2E89F697986EC3 /* ActionTests.swift */,
+				AA05FBAE0C5568412CAFA463 /* AsyncActionTests.swift */,
+				E1C2CCBE493D877533D458B4 /* MiddlewareTests.swift */,
+				D317D8705BD1D45086923B7A /* SideEffectTests.swift */,
+				3B0974E905FA04CAA8A08501 /* ActionLinkerTests.swift */,
+				C4C001D947DB3EF35D7C3E55 /* StoreTests.swift */,
+			);
+			name = Core;
+			path = Core;
+			sourceTree = "<group>";
+		};
+		6A534062C2A5A1C279EE3157 /* Katana */ = {
+			isa = PBXGroup;
+			children = (
+				C823FF9D1EC1F0191C2706B2 /* Middleware */,
+				B55D4329060E5566C5C511D3 /* State.swift */,
+				BE4DEC57EB7096DF649A2088 /* StoreTypealiases.swift */,
+				48EEEC8C752531D111DF5464 /* AsyncAction.swift */,
+				DEAC904C2B187E39817AA3F8 /* Store.swift */,
+				0ED7C7CC4753A0DF3C219D63 /* SideEffectDependencyContainer.swift */,
+				06F7E742842D432C653DAB07 /* Action.swift */,
+				864B4A5F02AC90EE3BFD265D /* ActionWithSideEffect.swift */,
+				B1C122C76A6DE3F4F01E039E /* Katana.h */,
+			);
+			name = Katana;
+			path = Katana;
+			sourceTree = "<group>";
+		};
+		7F5E822A9788643A76536190 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				2C968701DA467FE7975B6BB6 /* Foundation.framework */,
+				5B231B01440E1EB17FB7B1A2 /* UIKit.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		87E49D5076F05F37DEDEFB1A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				532F9A15268446A1A717F376 /* KatanaTests.xctest */,
+				636EEC3252E8A6CB694674BE /* Katana.framework */,
+				BD309159693A6220D827E358 /* Demo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9BC6CCBB49DF873057FB583E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7F5E822A9788643A76536190 /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C823FF9D1EC1F0191C2706B2 /* Middleware */ = {
+			isa = PBXGroup;
+			children = (
+				45D916B55035B3B103454C0D /* ActionLinker */,
+			);
+			name = Middleware;
+			path = Middleware;
+			sourceTree = "<group>";
+		};
+		E0F4B4E4DFEB760E5CC32846 /* Logic */ = {
+			isa = PBXGroup;
+			children = (
+				F838BF29F93F3031EAEEFA6F /* AppState.swift */,
+				AD3227752FD9A9395EE8413C /* AppDependenciesContainer.swift */,
+				A6128DF0A9C17FDBB9F23CD8 /* Actions.swift */,
+			);
+			name = Logic;
+			path = Logic;
+			sourceTree = "<group>";
+		};
+		EB5D218DE7E469F590BF5DE5 /* KatanaTests */ = {
+			isa = PBXGroup;
+			children = (
+				53DF333701C3230CCE783ECC /* Core */,
+				41293D8E23BA15526BA2E0AF /* Models */,
+			);
+			name = KatanaTests;
+			path = KatanaTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		856751C36384544D8B6847D7 /* Headers */ = {
+		39925823C3C4B66FCF008EAB /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E3F40F56CCCD4F628E9A5E65 /* Katana.h in Headers */,
+				BE2C2232926B6EC0745A19F4 /* Katana.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		3B432D1262379ABA0087C762 /* KatanaTests */ = {
+		098CF291D1F25D75E1EFD614 /* Demo */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1B9CAB86C0E4B85B3BCBAD77 /* Build configuration list for PBXNativeTarget "KatanaTests" */;
+			buildConfigurationList = 43C06A351E7FEF59C18CD68A /* Build configuration list for PBXNativeTarget "Demo" */;
 			buildPhases = (
-				8B69045F55CA9F5A0A3F79D8 /* Frameworks */,
-				E74AC65EC5EBC77BEFF0DA5B /* Sources */,
+				DA0A9632A63BC84EE48C8209 /* Frameworks */,
+				6582F56C41B6A95218F6807D /* Sources */,
+				62EB118F8FDE20D69C32093D /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				71396B134599B3480E586C48 /* PBXTargetDependency */,
+				9BDE1B733AEB90547C3C1A95 /* PBXTargetDependency */,
+			);
+			name = Demo;
+			productName = Demo;
+			productReference = BD309159693A6220D827E358 /* Demo.app */;
+			productType = "com.apple.product-type.application";
+		};
+		11A73E433030C20D8810D03A /* KatanaTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0D3AFD4E546F09F143D19C04 /* Build configuration list for PBXNativeTarget "KatanaTests" */;
+			buildPhases = (
+				E402E0812A9E329AE4F99529 /* Frameworks */,
+				840555A9164D780BFA24486E /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2DC00846E33EF7D10F252250 /* PBXTargetDependency */,
 			);
 			name = KatanaTests;
 			productName = KatanaTests;
-			productReference = 2DF25517DA1C72FF42676516 /* KatanaTests.xctest */;
+			productReference = 532F9A15268446A1A717F376 /* KatanaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		42B7BB264BF676AF4E06588C /* Katana */ = {
+		64F0E5CC681AAB7322579B9F /* Katana */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 80D15F53F58A4D955B18DBC8 /* Build configuration list for PBXNativeTarget "Katana" */;
+			buildConfigurationList = 1F96BCFEEF319420B770BE34 /* Build configuration list for PBXNativeTarget "Katana" */;
 			buildPhases = (
-				16B3825B2EE2E4CD549EB01D /* Frameworks */,
-				9D3C8B198CB1B99B0A1A2562 /* Sources */,
-				856751C36384544D8B6847D7 /* Headers */,
+				10F9B68D00ACBE229E4F4C83 /* Frameworks */,
+				738A96F749341C9AD05977B6 /* Sources */,
+				39925823C3C4B66FCF008EAB /* Headers */,
 			);
 			buildRules = (
 			);
@@ -310,133 +328,115 @@
 			);
 			name = Katana;
 			productName = Katana;
-			productReference = 9335F2EB9A93914CA5FED149 /* Katana.framework */;
+			productReference = 636EEC3252E8A6CB694674BE /* Katana.framework */;
 			productType = "com.apple.product-type.framework";
-		};
-		CC7551DB880AB8C346F1660A /* Demo */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 31032A342C9638A0B662523A /* Build configuration list for PBXNativeTarget "Demo" */;
-			buildPhases = (
-				898649A1F991AD1767C3DAEF /* Frameworks */,
-				06A6CEBAFBB6C52C4DB3B228 /* Sources */,
-				B6799F9B03D8B0F3370F16DF /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				7DD1B08BC25A392C799861CA /* PBXTargetDependency */,
-			);
-			name = Demo;
-			productName = Demo;
-			productReference = AC908790248DA785CE86881E /* Demo.app */;
-			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		BB5AA88D8AB3B8C68652A7B6 /* Project object */ = {
+		DEC633B4258B2EDC10FF3657 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 0930;
 			};
-			buildConfigurationList = 1F66CFF9204A7D61332576BE /* Build configuration list for PBXProject "Katana" */;
+			buildConfigurationList = D221ABA2E24C006EFA99030B /* Build configuration list for PBXProject "Katana" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = EAFA2A6432679B90EA11021E;
-			productRefGroup = 40032F61E85025482496B4C7 /* Products */;
+			mainGroup = 0FAC3E0D8C2651C3C9C622C6;
+			productRefGroup = 87E49D5076F05F37DEDEFB1A /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				3B432D1262379ABA0087C762 /* KatanaTests */,
-				42B7BB264BF676AF4E06588C /* Katana */,
-				CC7551DB880AB8C346F1660A /* Demo */,
+				11A73E433030C20D8810D03A /* KatanaTests */,
+				64F0E5CC681AAB7322579B9F /* Katana */,
+				098CF291D1F25D75E1EFD614 /* Demo */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		B6799F9B03D8B0F3370F16DF /* Resources */ = {
+		62EB118F8FDE20D69C32093D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2071A57C771B42E563B28555 /* LaunchScreen.storyboard in Resources */,
+				434FFA556E68C7EF19C42873 /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		06A6CEBAFBB6C52C4DB3B228 /* Sources */ = {
+		6582F56C41B6A95218F6807D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				528A5A20C8782B6D24F433B5 /* AppState.swift in Sources */,
-				767E331261481CBFB4DF3A6C /* AppDependenciesContainer.swift in Sources */,
-				2AB8A3A90933E45C37EF614C /* Actions.swift in Sources */,
-				D118ACA3C8E027E95AF1CB36 /* UIColor+Demo.swift in Sources */,
-				2A6FD0BC8DEEA2A64BB8D1D7 /* CounterViewController.swift in Sources */,
-				00EB19DB70DF3B5B661654F9 /* CounterView.swift in Sources */,
-				CB35F709496B20057D0171AD /* AppDelegate.swift in Sources */,
+				D769081A46AEA0354AB3F92B /* AppState.swift in Sources */,
+				F5A8BA27244200B1E365A368 /* AppDependenciesContainer.swift in Sources */,
+				0F0BB9C7D353843E25AE69C8 /* Actions.swift in Sources */,
+				C8BD88BB2D5643BC2CE58A9A /* UIColor+Demo.swift in Sources */,
+				11F033D469440A5F496D3DB5 /* CounterViewController.swift in Sources */,
+				D37A0AD9367388AA828B0CA5 /* CounterView.swift in Sources */,
+				6076D1E3340CF3C5C401B395 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9D3C8B198CB1B99B0A1A2562 /* Sources */ = {
+		738A96F749341C9AD05977B6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D361175E4AD6D0DA64149FB /* LinkeableAction.swift in Sources */,
-				F6A0A985A17EBBD6902C8178 /* ActionLinker.swift in Sources */,
-				E91901F91C0347CC1CB5217B /* ActionLinks.swift in Sources */,
-				E8CDCADFBDC57E370BFA47B9 /* State.swift in Sources */,
-				3169E285F0E9CE120542895A /* StoreTypealiases.swift in Sources */,
-				8D31B681605C41BDEC8671D7 /* AsyncAction.swift in Sources */,
-				C056AD28CAE48B67A37C4BB0 /* Store.swift in Sources */,
-				CAE0BED835FBA4F3164FE673 /* SideEffectDependencyContainer.swift in Sources */,
-				B9803C960217691B5EA10E43 /* Action.swift in Sources */,
-				58ED88F2B7CCF277F02C68C2 /* ActionWithSideEffect.swift in Sources */,
+				CF6EA40CA61E19BCDA3AF191 /* LinkeableAction.swift in Sources */,
+				36B04AEE8C4024997C5C73FE /* ActionLinker.swift in Sources */,
+				80AB3E91667CC034B3336FD7 /* ActionLinks.swift in Sources */,
+				CF1772694E2C6C1D7C64CD1D /* State.swift in Sources */,
+				1789AB64F62B2DCF72B23714 /* StoreTypealiases.swift in Sources */,
+				17CB2EF8D7FFD65009E53331 /* AsyncAction.swift in Sources */,
+				8BB909344DCABB8A1E493544 /* Store.swift in Sources */,
+				FAE0D8B11A23939284681D3D /* SideEffectDependencyContainer.swift in Sources */,
+				EC5B0FB8F7AC440E857492E6 /* Action.swift in Sources */,
+				4D1475F65A102B36B7B7713B /* ActionWithSideEffect.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E74AC65EC5EBC77BEFF0DA5B /* Sources */ = {
+		840555A9164D780BFA24486E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				23A87CFD92C3F6431BD4DDEA /* ActionTests.swift in Sources */,
-				E3F890459C304230682A39EA /* AsyncActionTests.swift in Sources */,
-				05F0D520A989F2E387338BF6 /* MiddlewareTests.swift in Sources */,
-				0AE44C78607D639F74CB5DA0 /* SideEffectTests.swift in Sources */,
-				3AD4A4AB0B6B9828CD24D19A /* ActionLinkerTests.swift in Sources */,
-				E8A7D327450E5408F3567B77 /* StoreTests.swift in Sources */,
-				24E7A11B84B5850A3272BC7B /* DependencyContainer.swift in Sources */,
-				F635D03DF471A031427F05D1 /* States.swift in Sources */,
-				6AD0A50E29C0BA163ED32E0D /* Actions.swift in Sources */,
+				C715E754BF65E9067CB0ED36 /* ActionTests.swift in Sources */,
+				9108C21F43B3BCB1B2ED7BC4 /* AsyncActionTests.swift in Sources */,
+				8D3CAE5D08970AD3BC970EA7 /* MiddlewareTests.swift in Sources */,
+				65BFB24E357D33FB58490BF4 /* SideEffectTests.swift in Sources */,
+				0F03F068C5707C48420E3A9B /* ActionLinkerTests.swift in Sources */,
+				CE833C2BF2E9BC9CB1D2AEF0 /* StoreTests.swift in Sources */,
+				48A4885AB2A541E461E282AA /* DependencyContainer.swift in Sources */,
+				D6F9577C75B3BEC7E830B0BD /* States.swift in Sources */,
+				9B3BC440D0BF5B7D9786BAB5 /* Actions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		71396B134599B3480E586C48 /* PBXTargetDependency */ = {
+		2DC00846E33EF7D10F252250 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Katana;
-			target = 42B7BB264BF676AF4E06588C /* Katana */;
-			targetProxy = 3562D2CA25FEB2A8020E4154 /* PBXContainerItemProxy */;
+			target = 64F0E5CC681AAB7322579B9F /* Katana */;
+			targetProxy = 43F7615D50ABCD54D146FF96 /* PBXContainerItemProxy */;
 		};
-		7DD1B08BC25A392C799861CA /* PBXTargetDependency */ = {
+		9BDE1B733AEB90547C3C1A95 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Katana;
-			target = 42B7BB264BF676AF4E06588C /* Katana */;
-			targetProxy = A56F7DBEEA793475BB4E7899 /* PBXContainerItemProxy */;
+			target = 64F0E5CC681AAB7322579B9F /* Katana */;
+			targetProxy = 76F8008FA19B56CCF2D38281 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		09FFA80C646B8C6974123986 /* Debug */ = {
+		11EA50D2BB3EFB564154ED08 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -444,13 +444,80 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		15FDD6EBE4BA2EEEEECE0F33 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = Demo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bendingspoons.Demo;
+				PRODUCT_NAME = Demo;
+				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
-		18BECA3CC938175FB62B78A1 /* Release */ = {
+		1770429133A6BB50DE572259 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		3D33A8852599E70099FC31B7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -468,7 +535,32 @@
 			};
 			name = Release;
 		};
-		4B10D79627D6427D4E1EE70A /* Debug */ = {
+		8EEC700EE71659FC5646B1D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Katana/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Katana;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		C6DD42468A4F2BB00EDF2ACF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -524,25 +616,7 @@
 			};
 			name = Debug;
 		};
-		61A7A5122CB5D8C5C31B0108 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bendingspoons.Demo;
-				PRODUCT_NAME = Demo;
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		6DA988CA4EE7D28E80CE314B /* Debug */ = {
+		F15D03A5908514285B9C1C3D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -558,16 +632,16 @@
 				PRODUCT_NAME = Katana;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Debug;
+			name = Release;
 		};
-		AEB12082AA9BCB42DF9828BE /* Release */ = {
+		F8CB848B0EEEDAF3EA418788 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -575,126 +649,52 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
-				VALIDATE_PRODUCT = YES;
 			};
-			name = Release;
-		};
-		C422B9908D69EA7133D21F43 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Katana/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = Katana;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		F64164DE3404CF7E23779B9D /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_ENABLE_OBJC_WEAK = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Release;
+			name = Debug;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1B9CAB86C0E4B85B3BCBAD77 /* Build configuration list for PBXNativeTarget "KatanaTests" */ = {
+		0D3AFD4E546F09F143D19C04 /* Build configuration list for PBXNativeTarget "KatanaTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				09FFA80C646B8C6974123986 /* Debug */,
-				AEB12082AA9BCB42DF9828BE /* Release */,
+				F8CB848B0EEEDAF3EA418788 /* Debug */,
+				11EA50D2BB3EFB564154ED08 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1F66CFF9204A7D61332576BE /* Build configuration list for PBXProject "Katana" */ = {
+		1F96BCFEEF319420B770BE34 /* Build configuration list for PBXNativeTarget "Katana" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4B10D79627D6427D4E1EE70A /* Debug */,
-				F64164DE3404CF7E23779B9D /* Release */,
+				8EEC700EE71659FC5646B1D3 /* Debug */,
+				F15D03A5908514285B9C1C3D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		31032A342C9638A0B662523A /* Build configuration list for PBXNativeTarget "Demo" */ = {
+		43C06A351E7FEF59C18CD68A /* Build configuration list for PBXNativeTarget "Demo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				61A7A5122CB5D8C5C31B0108 /* Debug */,
-				18BECA3CC938175FB62B78A1 /* Release */,
+				15FDD6EBE4BA2EEEEECE0F33 /* Debug */,
+				3D33A8852599E70099FC31B7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		80D15F53F58A4D955B18DBC8 /* Build configuration list for PBXNativeTarget "Katana" */ = {
+		D221ABA2E24C006EFA99030B /* Build configuration list for PBXProject "Katana" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6DA988CA4EE7D28E80CE314B /* Debug */,
-				C422B9908D69EA7133D21F43 /* Release */,
+				C6DD42468A4F2BB00EDF2ACF /* Debug */,
+				1770429133A6BB50DE572259 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = BB5AA88D8AB3B8C68652A7B6 /* Project object */;
+	rootObject = DEC633B4258B2EDC10FF3657 /* Project object */;
 }

--- a/Katana.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/Katana.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CC7551DB880AB8C346F1660A"
+               BlueprintIdentifier = "098CF291D1F25D75E1EFD614"
                BlueprintName = "Demo"
                ReferencedContainer = "container:Katana.xcodeproj"
                BuildableName = "Demo.app">
@@ -46,7 +46,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CC7551DB880AB8C346F1660A"
+            BlueprintIdentifier = "098CF291D1F25D75E1EFD614"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Katana.xcodeproj"
             BuildableName = "Demo.app">
@@ -62,7 +62,7 @@
       <BuildableProductRunnable>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CC7551DB880AB8C346F1660A"
+            BlueprintIdentifier = "098CF291D1F25D75E1EFD614"
             BlueprintName = "Demo"
             ReferencedContainer = "container:Katana.xcodeproj"
             BuildableName = "Demo.app">

--- a/Katana.xcodeproj/xcshareddata/xcschemes/Katana.xcscheme
+++ b/Katana.xcodeproj/xcshareddata/xcschemes/Katana.xcscheme
@@ -7,103 +7,91 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForAnalyzing = "YES"
             buildForTesting = "NO"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "42B7BB264BF676AF4E06588C"
-               BuildableName = "Katana.framework"
+               BlueprintIdentifier = "64F0E5CC681AAB7322579B9F"
                BlueprintName = "Katana"
-               ReferencedContainer = "container:Katana.xcodeproj">
+               ReferencedContainer = "container:Katana.xcodeproj"
+               BuildableName = "Katana.framework">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
+            buildForAnalyzing = "YES"
             buildForTesting = "YES"
             buildForRunning = "NO"
             buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForArchiving = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3B432D1262379ABA0087C762"
-               BuildableName = "KatanaTests.xctest"
+               BlueprintIdentifier = "11A73E433030C20D8810D03A"
                BlueprintName = "KatanaTests"
-               ReferencedContainer = "container:Katana.xcodeproj">
+               ReferencedContainer = "container:Katana.xcodeproj"
+               BuildableName = "KatanaTests.xctest">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <AdditionalOptions>
+      </AdditionalOptions>
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3B432D1262379ABA0087C762"
-               BuildableName = "KatanaTests.xctest"
+               BlueprintIdentifier = "11A73E433030C20D8810D03A"
                BlueprintName = "KatanaTests"
-               ReferencedContainer = "container:Katana.xcodeproj">
+               ReferencedContainer = "container:Katana.xcodeproj"
+               BuildableName = "KatanaTests.xctest">
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "42B7BB264BF676AF4E06588C"
-            BuildableName = "Katana.framework"
-            BlueprintName = "Katana"
-            ReferencedContainer = "container:Katana.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      buildConfiguration = "Debug"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "42B7BB264BF676AF4E06588C"
-            BuildableName = "Katana.framework"
-            BlueprintName = "Katana"
-            ReferencedContainer = "container:Katana.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
       <AdditionalOptions>
       </AdditionalOptions>
-   </LaunchAction>
-   <ProfileAction
-      buildConfiguration = "Debug"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      savedToolIdentifier = ""
-      useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "42B7BB264BF676AF4E06588C"
-            BuildableName = "Katana.framework"
+            BlueprintIdentifier = "64F0E5CC681AAB7322579B9F"
             BlueprintName = "Katana"
-            ReferencedContainer = "container:Katana.xcodeproj">
+            ReferencedContainer = "container:Katana.xcodeproj"
+            BuildableName = "Katana.framework">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "64F0E5CC681AAB7322579B9F"
+            BlueprintName = "Katana"
+            ReferencedContainer = "container:Katana.xcodeproj"
+            BuildableName = "Katana.framework">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/KatanaTests/Core/ActionLinkerTests.swift
+++ b/KatanaTests/Core/ActionLinkerTests.swift
@@ -59,8 +59,11 @@ class ActionLinkerTests: XCTestCase {
   func testNoChaining() {
     let expectation = self.expectation(description: "Store listener")
     
-    let store = Store<ActionLinkerAppState>(middleware: [ActionLinker.middleware(for: [])],
-                                            dependencies: EmptySideEffectDependencyContainer.self)
+    let store = Store<ActionLinkerAppState>(
+      middleware: [ActionLinker.middleware(for: [])],
+      dependencies: EmptySideEffectDependencyContainer.self
+    )
+    
     _ = store.addListener { expectation.fulfill() }
     store.dispatch(BaseAction())
     XCTAssertTrue(true)


### PR DESCRIPTION
Add the API to give to Katana a closure that can customise the initial state of the store.
This can be used to implement state restoration middleware or simplify test cases