### PR TITLE
[PROPOSAL] enhanced app structuring

### DIFF
--- a/BSP_GUIDELINES.md
+++ b/BSP_GUIDELINES.md
@@ -129,7 +129,8 @@ Assuming we have an application with two logic modules (Login and Plan Generator
 ProjectName
     |-- Logic
           |-- AppDependenciesContainer.swift
-          |-- Home.swift          
+          |-- Home
+                |-- Home.swift          
           |-- Login
                 |-- Login.swift // side effects and state updaters
                 |-- LoginManager.swift
@@ -141,6 +142,7 @@ ProjectName
           |-- Login
                 |-- LoginVC.swift
                 |-- LoginView.swift    
+                |-- LoginVM.swift    
           |-- Home
                 |-- HomeVC.swift
                 |-- HomeView.swift    
@@ -153,11 +155,11 @@ As you can see, the main folder contains 3 main folders: Logic, UI and State.
 
 The logic folder contains all the logic of the application (state updaters, side effects and managers) and the dependencies container.
 
-The logic is based on [guideline (4)](#4-leverage-encapsulation-modularisation-and-visibility-modifiers). When all the logic is in a single file (e.g., Home.swift, which holds side effects strictly related to the `Home` view controller), the file should be directly in the logic folder. In any other case, the files should be grouped using folders (e.g., Login and Plan Generator). Overall logic should contain side effects, state updaters, managers and models related to the logic.
+The logic is based on [guideline (4)](#4-leverage-encapsulation-modularisation-and-visibility-modifiers). Even if all the logic is in a single file (e.g., Home.swift, which holds side effects strictly related to the `Home` view controller), the file should be included in a folder to faciliate the search without having to guess if it's a folder or a file. Overall logic should contain side effects, state updaters, managers and models related to the logic.
 
 The State folder contains all the structures that are part of the state. Note that, following  [guideline (4)](#4-leverage-encapsulation-modularisation-and-visibility-modifiers), you may want to co-locate the state with the logic to implement some information-hiding technique to your code (that is, put some variables private or file-private). This is the only allowed exception.
 
-The UI folder is represented just for reference and should follow Tempura (or any other UI framework you are using) guidelines.
+The UI folder is represented just for reference and should follow Tempura (or any other UI framework you are using) guidelines. It is important to note that the VM should always be seperated from the view to faciliate the lookup.
 
 ## How to contribute
 

--- a/BSP_GUIDELINES.md
+++ b/BSP_GUIDELINES.md
@@ -141,8 +141,7 @@ ProjectName
     |-- UI
           |-- Login
                 |-- LoginVC.swift
-                |-- LoginView.swift    
-                |-- LoginVM.swift    
+                |-- LoginView.swift  
           |-- Home
                 |-- HomeVC.swift
                 |-- HomeView.swift    
@@ -159,7 +158,7 @@ The logic is based on [guideline (4)](#4-leverage-encapsulation-modularisation-a
 
 The State folder contains all the structures that are part of the state. Note that, following  [guideline (4)](#4-leverage-encapsulation-modularisation-and-visibility-modifiers), you may want to co-locate the state with the logic to implement some information-hiding technique to your code (that is, put some variables private or file-private). This is the only allowed exception.
 
-The UI folder is represented just for reference and should follow Tempura (or any other UI framework you are using) guidelines. It is important to note that the VM should always be seperated from the view to faciliate the lookup.
+The UI folder is represented just for reference and should follow Tempura (or any other UI framework you are using) guidelines.
 
 ## How to contribute
 


### PR DESCRIPTION
*WHAT*?
======
This PR proposes the following changes to the current BSP guidelines:

1- No logic files should be outside of folders
2- VM should always be in its own file

*WHY*?
=======
Both proposed changes are aiming to enhance visual lookup without having to wonder where a piece of information is.

In case of point 1:
XCode orders folders and files separately by default. So if you add a new file it's automatically added to the bottom of the current parent folder whereas a folder is added to the start of it. So having files outside of folders would polute the structure of the parent folder. In addition by having all files in folders, by simply right clicking and ordering by type (and silently alphabetically -- folders are automatically put in an alphabetical order) it would be easier to find something knowing its name by quickly going over alphabetically ordered folders. This is especially efficient with large projects, contrary to current guidelines which suggest to keep single files out of folder and thus making them harder to find, having to guess first if it's a folder or a single file, and then looking for it.

In case of point 2:
By having the VM always in its own file, there is no need to guess if a view has already a VM or not, where that VM is, in which part of the code is? top or bottom of the view etc.. It would save time and make everything clearer visually. It's easy to enforce during PR reviews. 