### PR TITLE
[Fix] Make SignpostLogger public

### DIFF
--- a/Katana/SignpostLogger.swift
+++ b/Katana/SignpostLogger.swift
@@ -17,7 +17,7 @@ import os.signpost
  
  - seeAlso: https://developer.apple.com/documentation/os/logging
 */
-struct SignpostLogger {
+public struct SignpostLogger {
   /// A closure that must be invoked when the operation is completed
   typealias LogEndClosure = () -> Void
   


### PR DESCRIPTION
**Why**
SignpostLogger isn't public so it is useless outside Katana.

**Changes**
* SignpostLogger becomes public