### PR TITLE
Move Promise “then” body outside the main thread

### DIFF
--- a/Katana/Promise+Katana.swift
+++ b/Katana/Promise+Katana.swift
@@ -28,7 +28,7 @@ public extension Promise {
   */
   @discardableResult
   func thenDispatch(_ dispatchable: Dispatchable) -> Promise<Void> {
-    return self.then { _ in
+    return self.then(in: .background) { _ in
       return SharedStoreContainer.sharedStore.dispatch(dispatchable)
     }
   }

--- a/Katana/Store.swift
+++ b/Katana/Store.swift
@@ -397,7 +397,7 @@ fileprivate extension Store {
     }
     
     // triggers the execution of the promise even though no one is listening for it
-    promise.then { _ in }
+    promise.then(in: .background) { _ in }
     
     return promise
   }
@@ -451,7 +451,7 @@ fileprivate extension Store {
     }
     
     // triggers the execution of the promise even though no one is listening for it
-    promise.then { _ in }
+    promise.then(in: .background) { _ in }
     
     return promise
   }
@@ -495,7 +495,7 @@ fileprivate extension Store {
     }
     
     // triggers the execution of the promise even though no one is listening for it
-    promise.then { _ in }
+    promise.then(in: .background) { _ in }
     
     return promise
   }


### PR DESCRIPTION
**Why**
Move some `Promise.then()` body to a background queue when execution on the main thread is not required or expected. 
This should result in a performance improvement for UI applications.

**Changes**
None, just implementation details.
Test are still passing.

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [ ] Ensure that all the examples (as well as the demo) work properly