### PR TITLE
Modify access level of PartialStore init

### DIFF
--- a/Katana/Dispatchable.swift
+++ b/Katana/Dispatchable.swift
@@ -18,7 +18,7 @@ public protocol Dispatchable: CustomDebugStringConvertible {}
 
 /// Implementation of the `CustomDebugStringConvertible` protocol
 public extension Dispatchable {
-  public var debugDescription: String {
+  var debugDescription: String {
     return String(reflecting: type(of: self))
   }
 }

--- a/Katana/Interceptor/ObserverInterceptor.swift
+++ b/Katana/Interceptor/ObserverInterceptor.swift
@@ -289,7 +289,7 @@ private struct ObserverLogic {
 
 public extension ObserverInterceptor {
   /// Enum that contains the various events that can be observed
-  public enum ObserverType {
+  enum ObserverType {
     
     /// Type of closure that is used to check whether a state change should trigger the event
     public typealias StateChangeObserver = (_ prev: State, _ current: State) -> Bool

--- a/Katana/Legacy/AsyncAction.swift
+++ b/Katana/Legacy/AsyncAction.swift
@@ -210,7 +210,7 @@ public extension AsyncAction {
    - parameter state:  the current state
    - returns: the new state
   */
-  public func updatedState(currentState: State) -> State {
+  func updatedState(currentState: State) -> State {
     switch self.state {
     case .loading:
       return self.updatedStateForLoading(currentState: currentState)
@@ -236,7 +236,7 @@ public extension AsyncAction {
    This new action will have the loading payload inerithed from the initial
    loading action and the provided additional information
   */
-  public func completedAction(_ configuration: (inout Self) -> () = { _ in }) -> Self {
+  func completedAction(_ configuration: (inout Self) -> () = { _ in }) -> Self {
     var copy = self
     copy.state = .completed
     configuration(&copy)
@@ -253,7 +253,7 @@ public extension AsyncAction {
    This new action will have the loading payload inerithed from the initial
    loading action and the provided additional information
    */
-  public func failedAction(_ configuration: (inout Self) -> () = { _ in }) -> Self {
+  func failedAction(_ configuration: (inout Self) -> () = { _ in }) -> Self {
     var copy = self
     copy.state = .failed
     configuration(&copy)
@@ -269,7 +269,7 @@ public extension AsyncAction {
    This new action will have the loading payload inerithed from the initial
    loading action and the defined progress value
   */
-  public func progressAction(percentage: Double) -> Self {
+  func progressAction(percentage: Double) -> Self {
     var copy = self
     copy.state = .progress(percentage: percentage)
     return copy

--- a/Katana/Promise+Katana.swift
+++ b/Katana/Promise+Katana.swift
@@ -41,7 +41,7 @@ public extension Promise {
    - returns: a chainable promise that will be resolved when the store will handle the dispatchable
   */
   @discardableResult
-  public func thenDispatch(_ body: @escaping ( (Value) throws -> Dispatchable) ) -> Promise<Void> {
+  func thenDispatch(_ body: @escaping ( (Value) throws -> Dispatchable) ) -> Promise<Void> {
     return self.then { value in
       let updater = try body(value)
       return SharedStoreContainer.sharedStore.dispatch(updater)

--- a/Katana/SideEffect.swift
+++ b/Katana/SideEffect.swift
@@ -196,7 +196,7 @@ public protocol SideEffect: AnySideEffect {
 /// Conformance of `SideEffect` to `AnySideEffect`
 public extension SideEffect {
   /// Implementation of the `sideEffect` requirement for `AnySideEffectContext`
-  public func sideEffect(_ context: AnySideEffectContext) throws {
+  func sideEffect(_ context: AnySideEffectContext) throws {
     guard let typedSideEffect = context as? SideEffectContext<StateType, Dependencies> else {
       fatalError("Invalid context pased to side effect")
     }

--- a/Katana/Store.swift
+++ b/Katana/Store.swift
@@ -545,7 +545,7 @@ fileprivate extension Store {
    - parameter previousState: the previous state
    - parameter currentState: the current state
    */
-  fileprivate func triggerSideEffect(for action: Action, previousState: S, currentState: S) {
+  func triggerSideEffect(for action: Action, previousState: S, currentState: S) {
     guard let action = action as? ActionWithSideEffect else {
       return
     }
@@ -569,10 +569,10 @@ fileprivate extension Store {
     Type used internally to store partially applied interceptors.
     (that is, an interceptor to which the Store has already passed the context)
   */
-  fileprivate typealias InitializedInterceptor = (_ next: @escaping StoreInterceptorNext) -> (_ dispatchable: Dispatchable) throws -> Void
+  typealias InitializedInterceptor = (_ next: @escaping StoreInterceptorNext) -> (_ dispatchable: Dispatchable) throws -> Void
   
   /// Type used to define a dispatch that can throw
-  fileprivate typealias ThrowingDispatch = (_: Dispatchable) throws -> Void
+  typealias ThrowingDispatch = (_: Dispatchable) throws -> Void
   
   /**
    A function that initialises the given interceptors by binding the
@@ -581,7 +581,7 @@ fileprivate extension Store {
    - parameter interceptors: the interceptors to use to create the chain
    - returns: an array of initialised interceptors
    */
-  fileprivate static func initializedInterceptors(
+  static func initializedInterceptors(
     _ interceptors: [StoreInterceptor],
     sideEffectContext: SideEffectContext<S, D>) -> [InitializedInterceptor] {
     
@@ -598,7 +598,7 @@ fileprivate extension Store {
    - parameter lastStep: the function to execute when all the intercepts are executed
    - returns: a single function that invokes all the interceptors and then the last step
   */
-  fileprivate static func chainedInterceptors(
+  static func chainedInterceptors(
     _ interceptors: [InitializedInterceptor],
     with lastStep: @escaping ThrowingDispatch) -> ThrowingDispatch {
 

--- a/Katana/Store.swift
+++ b/Katana/Store.swift
@@ -66,7 +66,7 @@ open class PartialStore<S: State>: AnyStore {
    Creates an instance of the `PartialStore` with the given initial state
    - parameter state: the initial state of the store
   */
-  fileprivate init(state: S) {
+  internal init(state: S) {
     self.state = state
   }
   

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ DEPENDENCIES:
   - Quick (~> 1.3)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - HydraAsync
     - Nimble
     - Quick
@@ -21,4 +21,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 02050a6e4aebe0534f0b88f05df416ee1adb6dea
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.8.4


### PR DESCRIPTION
**Why**
This PR modifies the access level of PartialStore init from `fileprivate` to `internal`, in order to allow to subclass it inside Test targets to create a mock version of it.

**Changes**
- modify the access level of PartialStore init from `fileprivate` to `internal`
- remove some warnings about redundant access levels

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [ ] Ensure that all the examples (as well as the demo) work properly