### PR TITLE
Refactor: let the store be garbage collected

### DIFF
--- a/Katana/Interceptor/ObserverInterceptor.swift
+++ b/Katana/Interceptor/ObserverInterceptor.swift
@@ -85,12 +85,16 @@ public struct ObserverInterceptor {
    Creates a new `ObserverInterceptor` that observes the passed events
    
    - parameter items: the list of events to observe
+   - parameter notificationCenter: the notificationCenter used to listen to notifications
    - returns: the interceptor that observes the given items
    */
-  public static func observe(_ items: [ObserverType]) -> StoreInterceptor {
+  public static func observe(
+    _ items: [ObserverType],
+    notificationCenter: NotificationCenter = .default
+  ) -> StoreInterceptor {
     return { context in
       
-      let logic = ObserverLogic(dispatch: context.anyDispatch, items: items)
+      let logic = ObserverLogic(dispatch: context.anyDispatch, items: items, notificationCenter: notificationCenter)
       logic.listenToNotifications()
       logic.handleOnStart()
       
@@ -119,6 +123,9 @@ private struct ObserverLogic {
   /// The items to observe
   let items: [ObserverInterceptor.ObserverType]
   
+  /// The notification center to listen on for notifications
+  let notificationCenter: NotificationCenter
+  
   /**
    Creates a new logic.
    
@@ -126,9 +133,14 @@ private struct ObserverLogic {
    - parameter items: the items to observe
    - returns: a structure that holds the logic to handle the given items
    */
-  init(dispatch: @escaping AnyDispatch, items: [ObserverInterceptor.ObserverType]) {
+  init(
+    dispatch: @escaping AnyDispatch,
+    items: [ObserverInterceptor.ObserverType],
+    notificationCenter: NotificationCenter = .default
+  ) {
     self.dispatch = dispatch
     self.items = items
+    self.notificationCenter = notificationCenter
   }
   
   /**
@@ -170,7 +182,7 @@ private struct ObserverLogic {
       }
     }
   }
-  
+    
   /**
    Handles a specific notification by adding an observer (using NotificationCenter)
    that dispatches the given types
@@ -183,7 +195,7 @@ private struct ObserverLogic {
     with name: NSNotification.Name,
     _ typesToDispatch: [NotificationObserverDispatchable.Type]) {
     
-    NotificationCenter.default.addObserver(
+    self.notificationCenter.addObserver(
       forName: name,
       object: nil,
       queue: nil,

--- a/Katana/SideEffect.swift
+++ b/Katana/SideEffect.swift
@@ -69,13 +69,13 @@ public extension AnySideEffectContext {
   /// Default implementation of the `dispatch<T: AnyStateUpdater>`
   @discardableResult
   func dispatch<T: AnyStateUpdater>(_ dispatchable: T) -> Promise<Void> {
-    return self.anyDispatch(dispatchable).void
+    return self.anyDispatch(dispatchable).voidInBackground
   }
 
   /// Default implementation of the `dispatch<T: AnySideEffect>`
   @discardableResult
   func dispatch<T: AnySideEffect>(_ dispatchable: T) -> Promise<Void> {
-    return self.anyDispatch(dispatchable).void
+    return self.anyDispatch(dispatchable).voidInBackground
   }
 
   /// Default implementation of the `dispatch<T: ReturningSideEffect>`
@@ -265,5 +265,13 @@ public extension SideEffect {
 
     try self.sideEffect(typedSideEffect)
     return ()
+  }
+}
+
+extension Promise {
+  /// Maps a promise hiding the return type. Note that this new promise
+  /// runs in the background
+  fileprivate var voidInBackground: Promise<Void> {
+    return self.then(in: .background) { _ in }
   }
 }

--- a/Katana/SideEffect.swift
+++ b/Katana/SideEffect.swift
@@ -64,7 +64,7 @@ public extension AnySideEffectContext {
 
   /// Default implementation of the `dispatch<T: ReturningSideEffect>`
   func dispatch<T: ReturningSideEffect>(_ dispatchable: T) -> Promise<T.ReturningValue> {
-    return self.anyDispatch(dispatchable).then { $0 as! T.ReturningValue }
+    return self.anyDispatch(dispatchable).then(in: .background) { $0 as! T.ReturningValue }
   }
 }
 
@@ -116,7 +116,7 @@ public struct SideEffectContext<S, D> where S: State, D: SideEffectDependencyCon
   */
   @discardableResult
   public func dispatch<T: ReturningSideEffect>(_ dispatchable: T) -> Promise<T.ReturningValue> {
-    return self.dispatchClosure(dispatchable).then { $0 as! T.ReturningValue }
+    return self.dispatchClosure(dispatchable).then(in: .background) { $0 as! T.ReturningValue }
   }
   
   /**

--- a/Katana/Store.swift
+++ b/Katana/Store.swift
@@ -423,10 +423,10 @@ open class Store<S: State, D: SideEffectDependencyContainer>: PartialStore<S> {
     }
     
     if let stateUpdater = dispatchable as? AnyStateUpdater {
-      return self.enqueueStateUpdater(stateUpdater).then { _ in }
+      return self.enqueueStateUpdater(stateUpdater).then(in: .background) { _ in }
       
     } else if let sideEffect = dispatchable as? AnySideEffect {
-      return self.enqueueSideEffect(sideEffect).then { (value: Any) in value }
+      return self.enqueueSideEffect(sideEffect).then(in: .background) { (value: Any) in value }
       
     }
     

--- a/Katana/Store.swift
+++ b/Katana/Store.swift
@@ -443,7 +443,7 @@ open class Store<S: State, D: SideEffectDependencyContainer>: PartialStore<S> {
   }
   
   /// This method is used to free all the references, since the store has some reference loops
-  /// going on with various entities. This meant to be called only when you are no longer using
+  /// going on with various entities. This is meant to be called only when you are no longer using
   /// the store and you want it to be garbage collected. Keep in mind this is not a safe method,
   /// if someone else still has a reference to the store and tries to dispatch something or
   /// to access the state/dependencies the application will crash.

--- a/Katana/Store.swift
+++ b/Katana/Store.swift
@@ -473,7 +473,7 @@ private extension Store {
     self.sideEffectQueue.resume()
     self.stateUpdaterQueue.resume()
     
-    // invoke listeners (we already are in the main queue)
+    // invoke listeners
     self.listeners.values.forEach { $0() }
   }
   

--- a/Katana/Store.swift
+++ b/Katana/Store.swift
@@ -468,16 +468,15 @@ private extension Store {
    */
   private func initializeInternalState(using stateInizializer: StateInitializer<S>) {
     self.state = stateInizializer()
-    // invoke listeners (always in main queue)
-    self.mainAsyncProvider.execute { [unowned self] in
-      self.listeners.values.forEach { $0() }
-    }
     self.initializedInterceptors = Store.initializedInterceptors(self.interceptors, sideEffectContext: self.sideEffectContext)
     
     // and here we are finally able to start the queues
     self.isReady = true
     self.sideEffectQueue.resume()
     self.stateUpdaterQueue.resume()
+    
+    // invoke listeners (we already are in the main queue)
+    self.listeners.values.forEach { $0() }
   }
   
   /**

--- a/Katana/Store.swift
+++ b/Katana/Store.swift
@@ -215,7 +215,7 @@ open class Store<S: State, D: SideEffectDependencyContainer>: PartialStore<S> {
   fileprivate var mainAsyncProvider: AsyncProvider!
     
   /// The queue used to handle the `StateUpdater` items
-  fileprivate var stateUpdaterQueue: DispatchQueue! = {
+  fileprivate var stateUpdaterQueue: DispatchQueue = {
     let d = DispatchQueue(label: "katana.stateupdater", qos: .userInteractive)
     
     // queue is initially supended. The store will enable the queue when
@@ -228,7 +228,7 @@ open class Store<S: State, D: SideEffectDependencyContainer>: PartialStore<S> {
   }()
   
   /// The queue used to handle the `SideEffect` items
-  fileprivate var sideEffectQueue: DispatchQueue! = {
+  fileprivate var sideEffectQueue: DispatchQueue = {
     let d = DispatchQueue(label: "katana.sideEffect", qos: .userInteractive, attributes: .concurrent)
     
     // queue is initially supended. The store will enable the queue when
@@ -452,8 +452,6 @@ open class Store<S: State, D: SideEffectDependencyContainer>: PartialStore<S> {
     self.dependencies = nil
     self.initializedInterceptors = []
     self.sideEffectContext = nil
-    self.stateUpdaterQueue = nil
-    self.sideEffectQueue = nil
     self.mainAsyncProvider = nil
   }
 }

--- a/Katana/Types.swift
+++ b/Katana/Types.swift
@@ -23,3 +23,17 @@ public typealias GetState = () -> State
 
 /// Typealias for the `Store.anyDispatch` function with the ability of managing the output with a promise
 public typealias AnyDispatch = (_: Dispatchable) -> Promise<Any>
+
+/// Entity capable of executing task asynchronously. This can be useful in tests to avoid launching tasks
+/// asynchrononously on some thread
+public protocol AsyncProvider {
+  /// Calling this method will enqueue a closure to be executed asyncrhonously
+  func execute(_ closure: @escaping () -> Void)
+}
+
+/// DispatchQueue conformance to `AsyncProvider` so that `DispatchQueue.main` can be used
+extension DispatchQueue: AsyncProvider {
+  public func execute(_ closure: @escaping () -> Void) {
+    self.async(execute: closure)
+  }
+}

--- a/Katana/Types.swift
+++ b/Katana/Types.swift
@@ -24,10 +24,9 @@ public typealias GetState = () -> State
 /// Typealias for the `Store.anyDispatch` function with the ability of managing the output with a promise
 public typealias AnyDispatch = (_: Dispatchable) -> Promise<Any>
 
-/// Entity capable of executing task asynchronously. This can be useful in tests to avoid launching tasks
-/// asynchrononously on some thread
+/// Entity capable of executing task asynchronously. This can be useful in tests to control asyncrhonous tasks
 public protocol AsyncProvider {
-  /// Calling this method will enqueue a closure to be executed asyncrhonously
+  /// Calling this method will enqueue a closure to be executed asynchronously
   func execute(_ closure: @escaping () -> Void)
 }
 

--- a/KatanaTests/ObserverInterceptorTests.swift
+++ b/KatanaTests/ObserverInterceptorTests.swift
@@ -217,42 +217,54 @@ class ObserverInterceptorTests: QuickSpec {
         let testNotification = Notification.Name("Test_Notification")
         
         it("works") {
-          let interceptor = ObserverInterceptor.observe([
-            .onNotification(testNotification, [StateChangeAddUser.self])
-          ])
-          
+          let notificationCenter = NotificationCenter()
+          let interceptor = ObserverInterceptor.observe(
+            [
+              .onNotification(testNotification, [StateChangeAddUser.self])
+            ],
+            notificationCenter: notificationCenter
+          )
+
           let store = Store<AppState, TestDependenciesContainer>(interceptors: [interceptor])
-          
+
           expect(store.isReady).toEventually(beTrue())
-          NotificationCenter.default.post(name: testNotification, object: nil)
-          
+          notificationCenter.post(name: testNotification, object: nil)
+
           expect(store.state.todo.todos.count).toEventually(equal(0))
           expect(store.state.user.users.count).toEventually(equal(1))
         }
         
         it("works with multiple items to dispatch") {
-          let interceptor = ObserverInterceptor.observe([
-            .onNotification(testNotification, [StateChangeAddUser.self, StateChangeAddUser.self])
-          ])
+          let notificationCenter = NotificationCenter()
+          let interceptor = ObserverInterceptor.observe(
+            [
+              .onNotification(testNotification, [StateChangeAddUser.self, StateChangeAddUser.self])
+            ],
+            notificationCenter: notificationCenter
+          )
           
           let store = Store<AppState, TestDependenciesContainer>(interceptors: [interceptor])
-          
+
           expect(store.isReady).toEventually(beTrue())
-          NotificationCenter.default.post(Notification(name: testNotification))
-          
+          notificationCenter.post(Notification(name: testNotification))
+
           expect(store.state.todo.todos.count).toEventually(equal(0))
           expect(store.state.user.users.count).toEventually(equal(2))
         }
         
         it("handles nil init") {
-          let interceptor = ObserverInterceptor.observe([
-            .onNotification(testNotification, [NilStateChangeAddUser.self, StateChangeAddUser.self])
-          ])
+          let notificationCenter = NotificationCenter()
+          let interceptor = ObserverInterceptor.observe(
+            [
+              .onNotification(testNotification, [NilStateChangeAddUser.self, StateChangeAddUser.self])
+            ],
+            notificationCenter: notificationCenter
+          )
           
-          let store = Store<AppState, TestDependenciesContainer>(interceptors: [interceptor])
+          let store = Store<AppState, TestDependenciesContainer>(interceptors: [interceptor, DispatchableLogger.interceptor()])
           
           expect(store.isReady).toEventually(beTrue())
-          NotificationCenter.default.post(Notification(name: testNotification))
+          notificationCenter.post(Notification(name: testNotification))
           
           expect(store.state.todo.todos.count).toEventually(equal(0))
           expect(store.state.user.users.count).toEventually(equal(1))

--- a/KatanaTests/ObserverInterceptorTests.swift
+++ b/KatanaTests/ObserverInterceptorTests.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Quick
 import Nimble
+
 @testable import Katana
 
 class ObserverInterceptorTests: QuickSpec {
@@ -145,11 +146,12 @@ class ObserverInterceptorTests: QuickSpec {
           ])
           
           let store = Store<AppState, TestDependenciesContainer>(interceptors: [interceptor])
-          
-          store.dispatch(MockSideEffet())
+                    
+          let promise = store.dispatch(MockSideEffect())
           
           expect(store.isReady).toEventually(beTrue())
           expect(invoked).toEventually(beFalse())
+          expect(promise.isPending).toEventually(beFalse())
         }
       }
       
@@ -393,7 +395,7 @@ OnStartObserverDispatchable {
   }
 }
 
-private struct MockSideEffet: ReturningTestSideEffect {
+private struct MockSideEffect: ReturningTestSideEffect {
   func sideEffect(_ context: SideEffectContext<AppState, TestDependenciesContainer>) throws -> AppState {
     return context.getState()
   }

--- a/KatanaTests/ObserverInterceptorTests.swift
+++ b/KatanaTests/ObserverInterceptorTests.swift
@@ -263,7 +263,7 @@ class ObserverInterceptorTests: QuickSpec {
             notificationCenter: notificationCenter
           )
           
-          let store = Store<AppState, TestDependenciesContainer>(interceptors: [interceptor, DispatchableLogger.interceptor()])
+          let store = Store<AppState, TestDependenciesContainer>(interceptors: [interceptor])
           
           expect(store.isReady).toEventually(beTrue())
           notificationCenter.post(Notification(name: testNotification))

--- a/KatanaTests/SideEffectTests.swift
+++ b/KatanaTests/SideEffectTests.swift
@@ -178,9 +178,7 @@ class SideEffectTests: QuickSpec {
           }
         }
         
-        it("retries dispatched dispatchables") {
-          store = Store<AppState, TestDependenciesContainer>()
-          
+        it("retries dispatched dispatchables") {          
           waitUntil(timeout: 10) { done in
             store.dispatch(RetryMe())
               .retry(2)


### PR DESCRIPTION
The Store has a fundamental problem: it creates various reference cycles to itself (e.g. through the dependencies or the sideeffectcontext) which basically make the store live forever. During the normal life cycle of our apps this is not a problem (since we normally have a single store that should be alive for the whole app lifetime), but in testing we need to create (and dispose!) of stores very frequently.

This PR adds an unsafe method that will break the reference loops and allows for the store to be garbage collected.

It also adds a small protocol encapsulation over `DispatchQueue.main` so that it can be more easily tested with the standard XCTest approach