### PR TITLE
Fix build for Swift 5.4

### DIFF
--- a/Katana/Interceptor/ObserverInterceptor.swift
+++ b/Katana/Interceptor/ObserverInterceptor.swift
@@ -342,9 +342,9 @@ public extension ObserverInterceptor {
     /**
      Observes a dispatch
      - parameter dispatchable: the type of the dispatchable to observe
-     - parameter dispatchable: a list of items to dispatch when `dispatchable` is dispatched
+     - parameter dispatchables: a list of items to dispatch when `dispatchable` is dispatched
      */
-    case onDispatch(_ dispatchable: Dispatchable.Type, _ dispatchable: [DispatchObserverDispatchable.Type])
+    case onDispatch(_ dispatchable: Dispatchable.Type, _ dispatchables: [DispatchObserverDispatchable.Type])
     
     /**
      Observes when the store starts


### PR DESCRIPTION
**Why**
As of Swift 5.4 (compiling using Xcode12.5-beta) when trying to build katana a compile error was thrown `Invalid redeclaration of ‘dispatchable’` since both params of the case declaration have the same param name. 

This fix does not impact any other part of the code and is limited to internal exposure and does not affect any public API. So it should be a quick patch.

**Changes**
List relevant API changes

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [ ] Ensure that all the examples (as well as the demo) work properly