### PR TITLE
Refactor Store initializer

### DIFF
--- a/Katana/Store.swift
+++ b/Katana/Store.swift
@@ -329,7 +329,7 @@ open class Store<S: State, D: SideEffectDependencyContainer>: PartialStore<S> {
     self.interceptors = interceptors
     self.isReady = false
 
-    let emptyState: S = emptyStateInitializer()
+    let emptyState: S = configuration.emptyStateInitializer()
     super.init(state: emptyState)
     
     self.dependencies = dependenciesInitializer(self.anyDispatchClosure, self.getStateClosure)
@@ -524,12 +524,17 @@ open class Store<S: State, D: SideEffectDependencyContainer>: PartialStore<S> {
     /// AsyncProvider used to run all the listeners
     let listenersAsyncProvider: AsyncProvider
     
+    /// Creates an intial empty state
+    let emptyStateInitializer: (() -> S)
+    
     public init(
       stateInitializerAsyncProvider: AsyncProvider = DispatchQueue.main,
-      listenersAsyncProvider: AsyncProvider = DispatchQueue.main
+      listenersAsyncProvider: AsyncProvider = DispatchQueue.main,
+      emptyStateInitializer: @escaping (() -> S) = { S() }
     ) {
       self.stateInitializerAsyncProvider = stateInitializerAsyncProvider
       self.listenersAsyncProvider = listenersAsyncProvider
+      self.emptyStateInitializer = emptyStateInitializer
     }
   }
 }


### PR DESCRIPTION
**Why**
Currently the Store when is initialized instantiate a new empty state and then asyncronously will set the `stateInitializer` value to the state.

In some XCUITests we need to instantiate a Store directly with a specific state, in this PR I've proposed a solution that allow to achieve this.

Another option is to provide another default initializer like this one for example:
```swift
init(
    interceptors: [StoreInterceptor],
    initialState: S,
    dependenciesInitializer: @escaping DependenciesInitializer,
    configuration: Configuration = .init()
  )
``` 
But I honestly prefer the proposed solution even if the API are less readable because I'm worried that the new initializer it could be mistakenly used instead of the other one.

**Changes**
Add a `emptyStateInitializer` property to `Configuration`

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [ ] Ensure that all the examples (as well as the demo) work properly