### PR TITLE
feat: pass old and new state to store listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Provide old and new state to `StoreListener`s. [#216](https://github.com/BendingSpoons/katana-swift/pull/216)
 - Bump Swift version to `5.0`. [#212](https://github.com/BendingSpoons/katana-swift/pull/212)
 - Pin Hydra minimum version to `2.0.6`. [#212](https://github.com/BendingSpoons/katana-swift/pull/212)
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ store.dispatch(IncrementCounter())
 You can ask the `Store` to be notified about every change in the app `State`.
 
 ```swift
-store.addListener() {
+store.addListener() { oldState, newState in
   // the app state has changed
 }
 ```

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -384,7 +384,7 @@ open class Store<S: State, D: SideEffectDependencyContainer>: PartialStore<S> {
    - returns: a closure that can be used to remove the listener
    */
   override public func addAnyListener(_ listener: @escaping AnyStoreListener) -> StoreUnsubscribe {
-    self.addListener { oldState, newState in
+    return self.addListener { oldState, newState in
       listener(oldState, newState)
     }
   }

--- a/Sources/Types.swift
+++ b/Sources/Types.swift
@@ -10,7 +10,7 @@ import Foundation
 import Hydra
 
 /**
- Typealias for the function that is invoked when the state changes.
+ Typealias for the type erased function that is invoked when the state changes.
 
  - parameter oldState: the state before the update
  - parameter newState: the state after the update

--- a/Sources/Types.swift
+++ b/Sources/Types.swift
@@ -10,10 +10,20 @@ import Foundation
 import Hydra
 
 /**
- Typealias for the function that is invoked to continues with the middleware
- chains.
+ Typealias for the function that is invoked when the state changes.
+
+ - parameter oldState: the state before the update
+ - parameter newState: the state after the update
  */
-public typealias StoreListener = () -> Void
+public typealias AnyStoreListener = (_ oldState: State, _ newState: State) -> Void
+
+/**
+ Typealias for the function that is invoked when the state changes.
+
+ - parameter oldState: the state before the update
+ - parameter newState: the state after the update
+ */
+public typealias StoreListener<S: State> = (_ oldState: S, _ newState: S) -> Void
 
 /// Typealias for the `Store` listener unsubscribe closure
 public typealias StoreUnsubscribe = () -> Void

--- a/Tests/StoreTests.swift
+++ b/Tests/StoreTests.swift
@@ -19,36 +19,44 @@ class StoreTest: XCTestCase {
   }
 
   func testListeners_areInvokedOnStateChange() {
-    var listenerState: AppState?
+    var listenerOldState: AppState?
+    var listenerNewState: AppState?
 
     let todo = Todo(title: "title", id: "id")
     let store = Store<AppState, TestDependenciesContainer>()
-    _ = store.addListener {
-      listenerState = store.state
+    _ = store.addListener { oldState, newState in
+      listenerOldState = oldState
+      listenerNewState = newState
     }
-    store.dispatch(AddTodo(todo: todo)).then {
-      XCTAssertEqual(listenerState?.todo.todos, [todo])
-    }
+    self.waitForPromise(
+      store.dispatch(AddTodo(todo: todo)).then {
+        XCTAssertEqual(listenerOldState?.todo.todos, [])
+        XCTAssertEqual(listenerNewState?.todo.todos, [todo])
+      }
+    )
   }
 
   func testUnsubscribeListeners_areInvokedOnStateChange() {
-    var listenerState: AppState?
+    var listenerOldState: AppState?
+    var listenerNewState: AppState?
 
     let todo = Todo(title: "title", id: "id")
     let store = Store<AppState, TestDependenciesContainer>()
-    let unsubscribe = store.addListener {
-      listenerState = store.state
+    let unsubscribe = store.addListener { oldState, newState in
+      listenerOldState = oldState
+      listenerNewState = newState
     }
     store
       .dispatch(AddTodo(todo: todo))
       .then {
-        XCTAssertEqual(listenerState?.todo.todos, [todo])
+        XCTAssertEqual(listenerOldState?.todo.todos, [])
+        XCTAssertEqual(listenerNewState?.todo.todos, [todo])
         unsubscribe()
       }
       .then { store.dispatch(AddTodo(todo: todo)) }
       .then {
-        XCTAssertEqual(listenerState?.todo.todos, [todo])
-        unsubscribe()
+        XCTAssertEqual(listenerOldState?.todo.todos, [])
+        XCTAssertEqual(listenerNewState?.todo.todos, [todo])
       }
   }
 }


### PR DESCRIPTION
**Why**
Fix for: https://github.com/BendingSpoons/katana-swift/issues/164

**Changes**
The `StoreListener` now receives in input typed app state.
To register a `StoreListener` on `AnyStore`, `addAnyListener` should be used instead.

**Tasks**
* [ ] Add relevant tests, if needed
* [ ] Add documentation, if needed
* [ ] Update README, if needed
* [ ] Ensure that all the examples (as well as the demo) work properly